### PR TITLE
Rest API サンプル（DB操作）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,4 @@ Homestead.json
 Homestead.yaml
 npm-debug.log
 yarn-error.log
-.env
 .phpunit.result.cache

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ Homestead.json
 Homestead.yaml
 npm-debug.log
 yarn-error.log
+.env
 .phpunit.result.cache

--- a/app/Http/Controllers/RestController.php
+++ b/app/Http/Controllers/RestController.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Restdata;
+use Illuminate\Http\Request;
+
+class RestController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        $items = Restdata::all();
+        return $items->toArray();
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        return view('rest.create');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        $restdata = new Restdata;
+        $form = $request->all();
+        unset($form['_token']);
+        $restdata->fill($form)->save();
+        return redirect('/rest');
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        $items = Restdata::find($id);
+        return $items->toArray();
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+      $target = Restdata::find($id);
+      return view('rest.create', ['form' => $target]);
+
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        $items = Restdata::find($id);
+        $form = $request->all();
+        unset($form['_token']);
+        $items->fill($form)->save();
+        return redirect('/rest');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        $items = Restdata::find($id)->delete();
+        return redirect('/rest');
+    }
+}

--- a/app/Restdata.php
+++ b/app/Restdata.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Restdata extends Model
+{
+    protected $table = 'restdata';
+    protected $guarded = array('id');
+
+    public static $rules = array(
+        'name' => 'required',
+        'message' => 'required'
+    );
+
+    public function getData()
+    {
+        return $this->name . ':' .$this->message;
+    }
+}

--- a/database/migrations/2018_11_05_010610_create_restdata_table.php
+++ b/database/migrations/2018_11_05_010610_create_restdata_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateRestdataTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('restdata', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('message');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('restdata');
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -12,5 +12,6 @@ class DatabaseSeeder extends Seeder
     public function run()
     {
         // $this->call(UsersTableSeeder::class);
+        $this->call(RestdataTableSeeder::class);
     }
 }

--- a/database/seeds/RestdataTableSeeder.php
+++ b/database/seeds/RestdataTableSeeder.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Restdata;
+use Illuminate\Database\Seeder;
+
+class RestdataTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $param = [
+            'name' => 'taro',
+            'message' => 'Hello World!',
+        ];
+        $restdata = new Restdata;
+        $restdata->fill($param)->save();
+        $param = [
+            'name' => 'hanako',
+            'message' => 'Enjoy Laravel!',
+        ];
+        $restdata = new Restdata;
+        $restdata->fill($param)->save();
+    }
+}

--- a/resources/views/rest/create.blade.php
+++ b/resources/views/rest/create.blade.php
@@ -1,0 +1,41 @@
+<html>
+<head>
+<title>REST_FORM</title>
+</head>
+<body>
+@if(isset($form))
+<h1>PUTを送信するフォーム</h1>
+<form action="/rest/{{$form->id}}" method="POST">
+{{ csrf_field() }}
+
+<input type="hidden" name="_method" value="PUT">
+NAME:<input type="text" name="name" value="{{$form->name}}"><br>
+MESSAGE:<input type="text" name="message" value="{{$form->message}}"><br>
+<input type="submit" value="send">
+</form>
+<hr>
+
+<h1>DELETEを送信するフォーム</h1>
+<form action="/rest/{{$form->id}}" method="POST">
+{{ csrf_field() }}
+<h5>NAME:{{$form->name}}</h5>
+ <h5>MESSAGE :{{$form->message}}</h5>
+ <input type="hidden" name="_method" value="DELETE">
+ <input type="submit" value="send">
+</form>
+
+
+@else
+<h1>POSTを送信するフォーム</h1>
+<form action="/rest" method="POST">
+{{ csrf_field() }}
+NAME:<input type="text" name="name"><br>
+MESSAGE:<input type="text" name="message"><br>
+<input type="submit" value="send">
+</form>
+
+<hr>
+@endif
+
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,3 +14,4 @@
 Route::get('/', function () {
     return view('welcome');
 });
+Route::resource('rest','RestController');


### PR DESCRIPTION
# 背景
対象タスク：
https://app.asana.com/0/894080321513627/894085173660835

# 詳細
## ①AWS EC2 にApache + PHP環境構築
http://18.182.74.2
laravelのトップページ

## ②RDSにDB名 testを作成
テーブルは、Laravelのmigrateにて作成します。

## ③Laravelのサンプルアプリ
https://qiita.com/MasaKu/items/82b9743383e73cb62c3e
を参考に以下を作成しました。

database/migrations/2018_11_05_010610_create_restdata_table.php
  restdataというテーブルを作成、id / name / message / timestampsを持ちます。

database/seeds/DatabaseSeeder.php
  restdataに初回登録するレコード2件を設定

app/Http/Controllers/RestController.php
  コントローラ：CRUD

app/Restdata.php
　モデル：テーブルrestdataの構造

resources/views/rest/create.blade.php
   ビュー：レコード追加と、編集・削除でビューを分けている

routes/web.php
　/restのルーティング追加

# 使い方
http://18.182.74.2/rest
restdataをすべて表示（json)

http://18.182.74.2/rest/create
登録画面を表示

http://18.182.74.2/rest/1
restdata(id=1）を表示


http://18.182.74.2/rest/1/edit
restdata(id=1)を編集or削除する画面を表示


