### PR TITLE
バグ修正

### DIFF
--- a/app/Http/Controllers/AskController.php
+++ b/app/Http/Controllers/AskController.php
@@ -111,6 +111,10 @@ class AskController extends MilestoneController
       if($request->has('key') && $this->is_enable_token($ret['access_key'])){
         $user = User::where('access_key', $ret['access_key'])->first();
         $user = $user->details();
+        $ret['user'] = $user;
+      }
+      else {
+        abort(403, 'このページへの操作期限が切れています');
       }
     }
     if(!isset($user)) {

--- a/app/Http/Controllers/TeacherController.php
+++ b/app/Http/Controllers/TeacherController.php
@@ -325,7 +325,7 @@ class TeacherController extends StudentController
        }
        $param['access_key'] = $access_key;
      }
-     $param['_edit'] = false;
+     $param['_edit'] = true;
      return view($this->domain.'.register',$param);
     }
     /**

--- a/app/Models/Ask.php
+++ b/app/Models/Ask.php
@@ -187,9 +187,9 @@ EOT;
     $item["duration"] = $this->start_date().'～'.$this->end_date();
     $item["start_date"] = $this->start_date();
     if($this->charge_user_id==1) $item["charge_user_name"] = "事務";
-    else $item["charge_user_name"] = $this->charge_user->details()->name();
-    $item["create_user_name"] = $this->create_user->details()->name();
-    $item["target_user_name"] = $this->target_user->details()->name();
+    else $item["charge_user_name"] = $this->charge_user->name;
+    $item["create_user_name"] = $this->create_user->name;
+    $item["target_user_name"] = $this->target_user->name;
     $item["end_dateweek"] = $this->end_dateweek();
     return $item;
   }
@@ -226,6 +226,7 @@ EOT;
       case "agreement":
         $ret = true;
         $is_complete = true;
+        //Trial->agreement()を実行
         $target_model_data->agreement($is_commit);
         break;
       case "rest_cancel":

--- a/app/Models/Teacher.php
+++ b/app/Models/Teacher.php
@@ -266,4 +266,9 @@ EOT;
     }
     return $items;
   }
+  public function regular(){
+    $this->user->update(['status' => 0]);
+    $this->update(['status' => 'regular']);
+    return $this;
+  }
 }

--- a/app/Models/Trial.php
+++ b/app/Models/Trial.php
@@ -986,8 +986,9 @@ EOT;
           $t = date('H:i:00', strtotime('+'.$this->course_minutes.'minute 2000-01-01 '.$time.'00'));
 
           foreach($teacher->user->calendar_settings as $setting){
-            //echo "B:".$week_day.'/'.$f."-".$t." / ".$setting->from_time_slot."-".$setting->to_time_slot."<br>";
-            if($setting->is_conflict_setting($week_day, $f,$t)==true){
+            if($setting->lesson_week != $week_day) continue;
+            //echo "B:".$week_day.'?='.$setting->lesson_week.'/'.$f."-".$t." / ".$setting->from_time_slot."-".$setting->to_time_slot."<br>";
+            if($setting->is_conflict_setting($week_day,$f,$t)==true){
               //echo "conflict!!<br>";
               $is_free = false;
               $data["status"] = "time_conflict";
@@ -995,14 +996,6 @@ EOT;
               break;
             }
           }
-          /*
-          if(isset($teacher_current_schedule) && isset($teacher_current_schedule[$week_day])
-            && isset($teacher_current_schedule[$week_day][$time]) && isset($teacher_current_schedule[$week_day][$time]->id)){
-              $is_free = false;
-              $data["status"] = "time_conflict";
-              $data["conflict_calendar_setting"] = $teacher_current_schedule[$week_day][$time];
-          }
-          */
         }
         //echo"[".$week_day."][".$time."][".$this->course_minutes."][".$is_free."]<br>";
         if($is_free===true){
@@ -1195,6 +1188,8 @@ EOT;
   public function agreement_ask($create_user_id, $access_key){
     //この体験に関してはいったん完了ステータス
     //保護者にアクセスキーを設定
+    \Log::warning("agreement_ask");
+
     $this->parent->user->update(['access_key' => $access_key]);
     $this->update(['status' => 'complete']);
 

--- a/app/Models/UserCalendar.php
+++ b/app/Models/UserCalendar.php
@@ -639,10 +639,11 @@ EOT;
       $data[$field] = $form[$field];
     }
 
-
+/*
     foreach($data as $field=>$val){
       \Log::warning($field."=".$val);
     }
+*/
     if(isset($data['status_name']))  unset($data['status_name']);
     $this->update($data);
     if($this->trial_id > 0 && isset($form['status'])){

--- a/app/Models/UserCalendarTag.php
+++ b/app/Models/UserCalendarTag.php
@@ -40,13 +40,24 @@ class UserCalendarTag extends UserTag
   }
   //1 key = n tagの場合利用する(上書き差し替え）
   public static function setTags($calendar_id, $tag_key, $tag_values, $create_user_id){
+
     UserCalendarTag::where('calendar_id', $calendar_id)
       ->where('tag_key' , $tag_key)->delete();
-    foreach($tag_values as $tag_value){
+    if(gettype($tag_values) == 'array'){
+      foreach($tag_values as $tag_value){
+        $item = UserCalendarTag::create([
+          'calendar_id' => $calendar_id,
+          'tag_key' => $tag_key,
+          'tag_value' => $tag_value,
+          'create_user_id' => $create_user_id,
+        ]);
+      }
+    }
+    else {
       $item = UserCalendarTag::create([
         'calendar_id' => $calendar_id,
         'tag_key' => $tag_key,
-        'tag_value' => $tag_value,
+        'tag_value' => $tag_values,
         'create_user_id' => $create_user_id,
       ]);
     }

--- a/resources/views/asks/agreement.blade.php
+++ b/resources/views/asks/agreement.blade.php
@@ -11,6 +11,7 @@
 @if($item->status=='new')
 <div id="admission_mail">
   <form method="POST" action="/asks/{{$item['id']}}/status_update/commit">
+    <input type="hidden" name="key" value="{{$access_key}}" />
     @component('trials.forms.admission_schedule', [ 'attributes' => $attributes, 'prefix'=>'', 'item' => $trial, 'domain' => $domain, 'input'=>false, 'active_tab' => 1]) @endcomponent
     @csrf
 	<input type="text" name="dummy" style="display:none;" / >

--- a/resources/views/components/page.blade.php
+++ b/resources/views/components/page.blade.php
@@ -61,13 +61,20 @@
       </div>
     @elseif(isset($action) && $action=='remind')
       @if(isset($item['email']))
-      <div class="col-12">
+      <div class="col-12" id="email_form">
         <div class="form-group">
           <label for="email">
             メールアドレス
             <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
           </label>
-          <input type="text" id="email" name="email" class="form-control" placeholder="例：hachioji@sakura.com"  required="true" inputtype="email" query_check="users/email" query_check_error="このメールアドレスは登録済みです" value="{{$item['email']}}">
+          <div class="w-100 email-edited">
+            <span>{{$item->email}}</span>
+            <a href="javascript:void(0);" onClick="email_form_edit()" class="btn btn-sm btn-success ml-2"><i class="fa fa-edit"></i></a>
+          </div>
+          <div class="w-100 email-edit" style="display:none;">
+            <input type="text" id="email" name="email" class="form-control w-50 float-left" placeholder="例：hachioji@sakura.com"  required="true" inputtype="email" query_check="users/email" query_check_error="このメールアドレスは登録済みです" value="{{$item['email']}}">
+            <a href="javascript:void(0);" onClick="email_form_edited()" class="btn btn-sm btn-success float-left mt-1 ml-2"><i class="fa fa-check"></i></a>
+          </div>
         </div>
       </div>
       <div class="col-12">
@@ -138,3 +145,28 @@
   </form>
   @endif
 </div>
+<script>
+function email_form_edit(){
+  $('div.email-edit').show();
+  $('div.email-edited').hide();
+}
+function email_form_edited(){
+  var email = $('div.email-edited span').text();
+  var new_email = $('input[name="email"]').val();
+  var is_check = false;
+  console.log(email+'=='+new_email);
+  if(email == new_email){
+    is_check = true;
+  }
+  else if(front.validateFormValue('email_form')){
+    is_check = true;
+  }
+  if(is_check){
+    $('div.email-edit').hide();
+    $('div.email-edited').show();
+    $('div.email-edited span').html(new_email);
+  }
+  return is_check;
+}
+
+</script>

--- a/resources/views/teachers/forms/bank_form.blade.php
+++ b/resources/views/teachers/forms/bank_form.blade.php
@@ -11,7 +11,7 @@
         {{__('labels.bank_no')}}
         <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
       </label>
-      <input type="text" id="bank_no" name="bank_no" class="form-control" placeholder="ex.0006" required="true" inputtype="number"
+      <input type="text" name="bank_no" class="form-control" placeholder="ex.0006" required="true" inputtype="number"
       @isset($item)
         value="{{$item['bank_no']}}"
       @else
@@ -26,7 +26,7 @@
         {{__('labels.bank_branch_no')}}
         <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
       </label>
-      <input type="text" id="bank_branch_no" name="bank_branch_no" class="form-control" placeholder="ex.215" required="true" inputtype="number"
+      <input type="text" name="bank_branch_no" class="form-control" placeholder="ex.215" required="true" inputtype="number"
       @isset($item)
         value="{{$item['bank_branch_no']}}"
       @endisset
@@ -56,7 +56,7 @@
         {{__('labels.bank_account_no')}}
         <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
       </label>
-      <input type="text" id="bank_account_no" name="bank_account_no" class="form-control" placeholder="ex.0012345" required="true" inputtype="number"
+      <input type="text" name="bank_account_no" class="form-control" placeholder="ex.0012345" required="true" inputtype="number"
       @isset($item)
         value="{{$item['bank_account_no']}}"
       @endisset
@@ -69,7 +69,7 @@
         {{__('labels.bank_account_name')}}
         <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
       </label>
-      <input type="text" id="bank_account_name" name="bank_account_name" class="form-control" placeholder="ex.ハチオウジ タロウ" required="true" inputtype="zenkakukana"
+      <input type="text" name="bank_account_name" class="form-control" placeholder="ex.ハチオウジ タロウ" required="true" inputtype="zenkakukana"
       @isset($item)
         value="{{$item['bank_account_name']}}"
       @endisset

--- a/resources/views/trials/forms/lesson_week.blade.php
+++ b/resources/views/trials/forms/lesson_week.blade.php
@@ -45,6 +45,7 @@
         @if($teacher->match_schedule['count'][$week_day] > 0)
           @if(isset($teacher->user->calendar_setting()['week'][$week_day]))
             @foreach($teacher->user->calendar_setting()['week'][$week_day] as $setting)
+            @if($setting->is_enable()==false) @continue @endif
             <tr id="{{$week_day}}_{{$setting["from_time_slot"]}}_{{$setting["to_time_slot"]}}" class="calendar_setting_row {{$week_day}}">
               <td class="action_form action_add">
                 <input class="form-check-input icheck flat-green" type="radio" name="calendar_setting_id" value="{{$setting->id}}" >

--- a/resources/views/trials/lists.blade.php
+++ b/resources/views/trials/lists.blade.php
@@ -103,28 +103,55 @@
     </a>
     <ul class="nav nav-treeview">
       <li class="nav-item">
-        <a href="/{{$domain}}?status=new" class="nav-link @if($_status=="new") active @endif">
-          <i class="fa fa-exclamation-triangle nav-icon"></i>未対応
+        <a href="/{{$domain}}?status=new" class="nav-link @if($_status=="today") active @endif">
+          <i class="fa fa-exclamation-triangle nav-icon"></i>
+          <p>
+            未対応
+            @if($new_count > 0)
+            <span class="badge badge-danger right">{{$new_count}}</span>
+            @endif
+          </p>
         </a>
       </li>
       <li class="nav-item">
         <a href="/{{$domain}}?status=confirm" class="nav-link @if($_status=="confirm") active @endif">
-          <i class="fa fa-check-circle nav-icon"></i>予定確認中
+          <i class="fa fa-calendar-plus nav-icon"></i>
+          <p>
+            体験授業登録済み
+            @if($confirm_count > 0)
+            <span class="badge badge-warning right">{{$confirm_count}}</span>
+            @endif
+          </p>
         </a>
       </li>
       <li class="nav-item">
-        <a href="/{{$domain}}?status=fix" class="nav-link @if($_status=="fix") active @endif">
-          <i class="fa fa-calendar-alt nav-icon"></i>授業予定
+        <a href="/{{$domain}}?status=complete" class="nav-link @if($_status=="complete") active @endif">
+          <i class="fa fa-check-circle nav-icon"></i>
+          <p>
+            入会案内連絡済
+            @if($complete_count > 0)
+            <span class="badge badge-success right">{{$complete_count}}</span>
+            @endif
+          </p>
         </a>
       </li>
       <li class="nav-item">
         <a href="/{{$domain}}?status=rest,cancel" class="nav-link @if($_status=="rest,cancel") active @endif">
-          <i class="fa fa-ban nav-icon"></i>キャンセル
+          <i class="fa fa-ban nav-icon"></i>
+          <p>
+            キャンセル
+            @if($cancel_count > 0)
+            <span class="badge badge-secondary right">{{$cancel_count}}</span>
+            @endif
+          </p>
         </a>
       </li>
       <li class="nav-item">
         <a href="/{{$domain}}" class="nav-link @if(empty($_status)) active @endif">
-          <i class="fa fa-history nav-icon"></i>履歴
+          <i class="fa fa-history nav-icon"></i>
+          <p>
+            履歴
+          </p>
         </a>
       </li>
       {{--


### PR DESCRIPTION
・登録依頼メールのフォームがすでに登録済みのメールにて送信できない
　→　編集も可能、送信も可能に対応

・体験一覧の件数表示追加

・入会承諾後、通常授業設定から起こしたカレンダーがnewでしか登録できなかった
　→　カレンダー登録時にステータス指定はできない
　　→　新規追加し、あらたにfixで更新するように対応

・体験詳細の通常授業設定で、無効な設定も表示されてしまう
　UserCalendarSetting->is_enableを追加
　is_enable==trueの場合のみ表示する

・teachers/forms/banl_form
 余計なidを除去