### PR TITLE
ダイアログの登録フォームを表示

### DIFF
--- a/app/Http/Controllers/StudentController.php
+++ b/app/Http/Controllers/StudentController.php
@@ -757,6 +757,11 @@ class StudentController extends UserController
          $form['search_type'] = ['teacher_change'];
        }
        break;
+     case "rest_cancel":
+       if(!isset($form['search_type'])){
+         $form['search_type'] = ['rest_cancel'];
+       }
+       break;
      case "lecture_cancel":
        if(!isset($form['search_type'])){
          $form['search_type'] = ['lecture_cancel'];

--- a/resources/views/components/search_word.blade.php
+++ b/resources/views/components/search_word.blade.php
@@ -1,7 +1,7 @@
 <div class="input-group mb-3">
   <input type="text" name="search_word" class="form-control" placeholder="{{__('labels.search_keyword')}}" value="{{$search_word}}" style="width:140px;" accesskey="keyword_search">
   <span class="input-group-append">
-    <button type="button" class="btn btn-submit btn-info btn-flat" id="search_button">
+    <button type="button" class="btn btn-info btn-flat" id="search_button">
       <i class="fa fa-search"></i>
     </button>
   </span>


### PR DESCRIPTION
↓
閉じる
↓
キーワード検索ボタン
↓
ダイアログ側のform.submitが発生する問題を解消

検索ボタンのbtn-submitをなくす

StudentController
get_askのrest_cancelがない