### PR TITLE
クエリビルダの埋め込みパラメータ数がずれるバグの修正

### DIFF
--- a/app/Models/UserCalendar.php
+++ b/app/Models/UserCalendar.php
@@ -108,14 +108,14 @@ class UserCalendar extends Model
   public function scopeSearchDate($query, $from_date, $to_date)
   {
     $where_raw = <<<EOT
-      ((user_calendars.start_time >= '$from_date'
-       AND user_calendars.start_time <= '$to_date'
+      ((user_calendars.start_time >= '?'
+       AND user_calendars.start_time <= '?'
       )
-      OR (user_calendars.end_time >= '$from_date'
-        AND user_calendars.end_time <= '$to_date'
+      OR (user_calendars.end_time >= '?'
+        AND user_calendars.end_time <= '?'
       ))
 EOT;
-    return $query->whereRaw($where_raw,[$from_date, $to_date]);
+    return $query->whereRaw($where_raw,[$from_date, $to_date, $from_date, $to_date]);
 
   }
   public function scopeSearchWord($query, $word)


### PR DESCRIPTION
     $calendars = UserCalendar::searchDate($start_time, $end_time)
                ->findStatuses(['cancel', 'rest', 'lecture_cancel', 'new'], true)
                ->where('place_floor_id', $this->id)->get();

searchDateの埋め込みパラメータ＝４つ
　　　　　　バインドしたパラメータ＝２つ

上記のＳＱＬは、パラメータが２こずれおこす