### PR TITLE
生徒がログインした場合の対応

### DIFF
--- a/resources/views/components/menu/navbar/account_nav.blade.php
+++ b/resources/views/components/menu/navbar/account_nav.blade.php
@@ -26,6 +26,7 @@
         </div>
       </div>
     </a>
+    @if($user->role!=="student")
     <a href="javascript:void(0);" class="dropdown-item"  page_title="{{__('labels.account_setting')}}" page_form="dialog" page_url="/{{$user["domain"]}}/{{$user->id}}/edit" >
       <i class="fa fa-user-edit mr-2"></i>{{__('labels.account_setting')}}
     </a>
@@ -38,6 +39,7 @@
     <a href="/faqs" class="dropdown-item" >
       <i class="fa fa-question-circle mr-2"></i>{{__('labels.faqs')}}
     </a>
+    @endif
     @if($user->role!=="parent")
       @if(app()->getLocale()=='en')
       <a href="/home?locale=ja" class="dropdown-item" >

--- a/resources/views/components/menu/navbar/user_nav.blade.php
+++ b/resources/views/components/menu/navbar/user_nav.blade.php
@@ -7,9 +7,9 @@
   </a>
 </li>
 <li class="nav-item">
-  <a alt="student_name" href="/students/{{$user->id}}/schedule" class="nav-link">
+  <a alt="student_name" href="/students/{{$user->id}}/schedule?list=month" class="nav-link">
     <i class="fa fa-clock"></i>
-    <span class="d-none d-sm-inline-block">{{__('labels.schedule_list')}}</span>
+    <span class="d-none d-sm-inline-block">{{__('labels.month_schedule_list')}}</span>
   </a>
 </li>
 @elseif($user->role==="parent")

--- a/resources/views/students/calendar.blade.php
+++ b/resources/views/students/calendar.blade.php
@@ -16,6 +16,7 @@
           @slot('event_click')
           eventClick: function(event, jsEvent, view) {
             $calendar.fullCalendar('unselect');
+            @if($user->role!='student')
             switch(event.own_member.status){
               case "confirm":
                 base.showPage('dialog', "subDialog", "予定確認", "/calendars/"+event.id+"/status_update/fix?student_id={{$item->id}}");
@@ -41,6 +42,9 @@
                 console.log("/calendars/"+event.id+"?student_id={{$item->id}}");
                 break;
             }
+            @else
+            base.showPage('dialog', "subDialog", "カレンダー詳細", "/calendars/"+event.id+"?student_id={{$item->id}}");
+            @endif
           },
           @endslot
         @endcomponent

--- a/resources/views/students/menu.blade.php
+++ b/resources/views/students/menu.blade.php
@@ -39,6 +39,7 @@
           </p>
         </a>
       </li>
+      @if($user->role!='student')
       <li class="nav-item">
         <a href="/{{$domain}}/{{$item->id}}/schedule?list=confirm" class="nav-link  @if($view=="schedule" && $list=="confirm") active @endif">
           <i class="fa fa-hourglass nav-icon"></i>
@@ -58,6 +59,7 @@
           </p>
         </a>
       </li>
+      @endif
       <li class="nav-item">
         <a href="/{{$domain}}/{{$item->id}}/schedule?list=exchange" class="nav-link @if($view=="schedule" && $list=="exchange") active @endif">
           <i class="fa fa-exchange-alt nav-icon"></i>
@@ -69,12 +71,14 @@
           </p>
         </a>
       </li>
+      @if($user->role!='student')
       <li class="nav-item">
         <a href="/{{$domain}}/{{$item->id}}/schedule?list=history" class="nav-link @if($view=="schedule" && $list=="history") active @endif">
           <i class="fa fa-history nav-icon "></i>
           {{__('labels.schedule_history')}}
         </a>
       </li>
+      @endif
     </ul>
   </li>
   <li class="nav-item has-treeview menu-open">
@@ -86,11 +90,13 @@
     </p>
     </a>
     <ul class="nav nav-treeview pl-2">
+      @if($user->role!='student')
       <li class="nav-item">
         <a class="nav-link" href="javascript:void(0);" page_form="dialog" page_url="/{{$domain}}/{{$item->id}}/edit" page_title="{{__('labels.students')}}{{__('labels.setting')}}">
           <i class="fa fa-user-edit nav-icon"></i>{{__('labels.students')}}{{__('labels.setting')}}
         </a>
       </li>
+      @endif
       <li class="nav-item">
         <a class="nav-link" href="javascript:void(0);"  page_form="dialog" page_url="/milestones/create?origin={{$domain}}&item_id={{$item->id}}" page_title="{{__('labels.milestones')}}{{__('labels.add')}}">
           <i class="fa fa-flag nav-icon"></i>{{__('labels.milestones')}}{{__('labels.add')}}

--- a/resources/views/students/page.blade.php
+++ b/resources/views/students/page.blade.php
@@ -62,6 +62,7 @@
               @endif
               @endforeach
             </h6>
+            {{--
             <div class="card-footer p-0">
               <ul class="nav flex-column">
                 @if(!empty($item->recess_duration()))
@@ -118,17 +119,19 @@
                     <i class="fa fa-user-edit mr-2"></i>{{__('labels.students')}}{{__('labels.setting')}}
                   </a>
                 </li>
-                {{--
-                <li class="nav-item">
-                  <a href="/examinations" class="nav-link active">
-                    <i class="fa fa-file-signature mr-2"></i>
-                    確認テスト
-                    <span class="float-right badge bg-danger">New</span>
-                  </a>
-                </li>
-                --}}
               </ul>
             </div>
+            --}}
+            {{--
+            <li class="nav-item">
+              <a href="/examinations" class="nav-link active">
+                <i class="fa fa-file-signature mr-2"></i>
+                確認テスト
+                <span class="float-right badge bg-danger">New</span>
+              </a>
+            </li>
+            --}}
+
           @endslot
       @endcomponent
 		</div>


### PR DESCRIPTION
account_nav.blade.php
FAQ・English変更のリンクのみ残す
他は使えなくする

user_nav.blade.php
今月予定に変更

students/page.blade.php
メニュー部分をコメントアウト

students/menu.blade.php
今月予定・振替・
目標・コメントのみ使えるようにする

students/calendar.blade.php
生徒がアクセスする場合は、詳細表示のみ