### PR TITLE
is_onlineタグの修正

### DIFF
--- a/app/Http/Controllers/UserCalendarController.php
+++ b/app/Http/Controllers/UserCalendarController.php
@@ -226,8 +226,7 @@ class UserCalendarController extends MilestoneController
     }
     $form['place_floor_id'] = $request->get('place_floor_id');
     $form['is_exchange'] = false;
-    $form['is_online'] = 'false';
-    if($request->has('is_online') && $request->get('is_online')=='true') $form['is_online'] = 'true';
+    if($request->has('is_online')) $form['is_online'] = $request->get('is_online');
     //事務の指定
     if($request->has('manager_id')){
       $form['manager_id'] = $request->get('manager_id');

--- a/app/Http/Controllers/UserCalendarSettingController.php
+++ b/app/Http/Controllers/UserCalendarSettingController.php
@@ -157,8 +157,7 @@ class UserCalendarSettingController extends UserCalendarController
           break;
       }
       $form['place'] = $request->get('place');
-      $form['is_online'] = 'false';
-      if($request->has('is_online') && $request->get('is_online')=='true') $form['is_online'] = 'true';
+      if($request->has('is_online')) $form['is_online'] = $request->get('is_online');
 
       //生徒と講師の情報が予定追加時には必須としている
       //講師の指定
@@ -263,8 +262,7 @@ class UserCalendarSettingController extends UserCalendarController
       }
 
       $form['place'] = $request->get('place');
-      $form['is_online'] = 'false';
-      if($request->has('is_online') && $request->get('is_online')=='true') $form['is_online'] = 'true';
+      if($request->has('is_online')) $form['is_online'] = $request->get('is_online');
 
       if($request->has('teacher_id')){
         //講師の指定

--- a/resources/views/calendar_settings/create.blade.php
+++ b/resources/views/calendar_settings/create.blade.php
@@ -170,7 +170,7 @@ $(function(){
         var _name = $('select[name='+value+'] option:selected').text().trim();
         form_data[value+"_name"] = _name;
         if(value=='place_floor_id'){
-          if($('input[name="is_online"]').prop('checked')){
+          if($('input[name="is_online"]').val()=='true'){
             form_data[value+"_name"] += '/ <i class="fa fa-globe"></i>{{__('labels.online')}}';
           }
         }

--- a/resources/views/calendar_settings/page.blade.php
+++ b/resources/views/calendar_settings/page.blade.php
@@ -24,11 +24,21 @@
             <label for="{{$key}}" class="w-100">
               {{$field['label']}}
             </label>
-            <small class="badge badge-success mt-1 mr-1">{{$item[$key]}}</small>
-            @if($item->is_online()==true)
-            <small class="badge badge-info mt-1 mr-1 text-sm">
-              <i class="fa fa-globe">{{__('labels.online')}}</i>
-            </small>
+            @if(!(isset($user) && ($user->role=="teacher" || $user->role=="manager")))
+              @if($item->is_online()==true)
+              <small class="badge badge-info mt-1 mr-1 text-sm">
+                <i class="fa fa-globe">{{__('labels.online')}}</i>
+              </small>
+              @else
+                <small class="badge badge-success mt-1 mr-1">{{$item[$key]}}</small>
+              @endif
+            @else
+              <small class="badge badge-success mt-1 mr-1">{{$item[$key]}}</small>
+              @if($item->is_online()==true)
+                <small class="badge badge-info mt-1 mr-1 text-sm">
+                  <i class="fa fa-globe">{{__('labels.online')}}</i>
+                </small>
+              @endif
             @endif
           @elseif($key==='student_name' && ($action!='delete' || $item->is_group()!=true))
             <label for="{{$key}}" class="w-100">

--- a/resources/views/calendars/create.blade.php
+++ b/resources/views/calendars/create.blade.php
@@ -177,8 +177,8 @@ $(function(){
           form_data[value+"_name"] = _name;
         }
         if(value=='place_floor_id'){
-          if($('input[name="is_online"]').prop('checked')){
-            form_data[value+"_name"] += '/ <i class="fa fa-globe"></i>{{__('labels.online')}}';            
+          if($('input[name="is_online"]').val()=='true'){
+            form_data[value+"_name"] += '/ <i class="fa fa-globe"></i>{{__('labels.online')}}';
           }
         }
       }

--- a/resources/views/calendars/forms/select_place.blade.php
+++ b/resources/views/calendars/forms/select_place.blade.php
@@ -20,15 +20,26 @@
         @endforeach
       </select>
       <div class="form-check mt-2 text-info">
-          <input class="form-check-input icheck flat-red" type="checkbox" name="is_online" id="is_online" value="true"
+          <input type="hidden" name="is_online" value="false" />
+          <input class="form-check-input icheck flat-red" type="checkbox" name="_is_online" id="is_online" value="true"
           @if($item->is_online()==true)
             checked
           @endif
+          onChange="is_online_click()"
           >
           <i class="fa fa-globe"></i>
           <label class="form-check-label" for="is_online">
               {{__('labels.online')}}
           </label>
+          <script>
+          function is_online_click(){
+            console.log('is_online_click');
+            $('input[name="is_online"]').val('false');
+            if($('input[name="_is_online"]').prop('checked')==true){
+              $('input[name="is_online"]').val('true');
+            }
+          }
+          </script>
       </div>
     </div>
   </div>

--- a/resources/views/calendars/page.blade.php
+++ b/resources/views/calendars/page.blade.php
@@ -25,11 +25,21 @@
           <label for="{{$key}}" class="w-100">
             {{$field['label']}}
           </label>
-          <small class="badge badge-success mt-1 mr-1">{{$item[$key]}}</small>
-          @if($item->is_online()==true)
-          <small class="badge badge-info mt-1 mr-1 text-sm">
-            <i class="fa fa-globe">{{__('labels.online')}}</i>
-          </small>
+          @if(!(isset($user) && ($user->role=="teacher" || $user->role=="manager")))
+            @if($item->is_online()==true)
+            <small class="badge badge-info mt-1 mr-1 text-sm">
+              <i class="fa fa-globe">{{__('labels.online')}}</i>
+            </small>
+            @else
+              <small class="badge badge-success mt-1 mr-1">{{$item[$key]}}</small>
+            @endif
+          @else
+            <small class="badge badge-success mt-1 mr-1">{{$item[$key]}}</small>
+            @if($item->is_online()==true)
+            <small class="badge badge-info mt-1 mr-1 text-sm">
+              <i class="fa fa-globe">{{__('labels.online')}}</i>
+            </small>
+            @endif
           @endif
         @elseif($key==='student_name' && ($action!='delete' || $item->is_group()!=true))
           <label for="{{$key}}" class="w-100">


### PR DESCRIPTION
更新時に取れてしまう問題を解消

生徒がis_online=trueで詳細表示した場合に、
オンラインと表示する
→　オンライン時のカレンダー・カレンダー設定に関する場所は、
　講師に対するものであるため