### PR TITLE
Feature/374

### DIFF
--- a/app/Http/Controllers/MessageController.php
+++ b/app/Http/Controllers/MessageController.php
@@ -28,7 +28,7 @@ class MessageController extends CommentController
       $user = $this->login_details($request);
       $role = $user->role;
       if( $role == 'manager'){
-        $messages = $this->model()->paginate(20);
+        $messages = $this->model()->paginate($param['_line']);
       }else{
         abort(403);
       }

--- a/app/Http/Controllers/StudentController.php
+++ b/app/Http/Controllers/StudentController.php
@@ -1266,7 +1266,7 @@ class StudentController extends UserController
 
  public function message_list(Request $request, $id = null){
     $params = $this->get_param($request, $id);
-    $messages = $this->message_search($request, $id);
+    $messages = $this->message_search($request, $id)->paginate($params['_line']);
     $login_user = $this->login_details($request);
     $fields = [
       'title' => [
@@ -1289,6 +1289,7 @@ class StudentController extends UserController
       'items' => $messages,
       'fields' => $fields,
       'search_list' => $request->get('search_list'),
+      'search_type' => $request->Get('search_type'),
       'id' => $id,
       'enable_create' => $enable_create,
     ];
@@ -1302,7 +1303,7 @@ class StudentController extends UserController
 //    $query = $query->where('parent_message_id','0');
     $query = $this->make_search_query($request, $query, $id);
     $query = $query->orderBy('created_at','desc');
-    $messages = $query->paginate(20);
+    $messages = $query;
     return $messages;
   }
 
@@ -1340,6 +1341,13 @@ class StudentController extends UserController
     }
     if($request->has('search_word')){
       $query = $query->searchWord($request->get('search_word'));
+    }
+    if($request->has('search_type') ){
+      if($request->get('search_type') == "parent_homework_request"){
+        $query = $query->findParentHomeworkRequest();
+      }else{
+        $query = $query->findTypes($request->get('search_type'));
+      }
     }
     return $query;
   }

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -47,9 +47,8 @@ class TaskController extends MilestoneController
           $target_parent = StudentParent::where( 'user_id', $message->create_user_id)->first();
           $target_students = Student::findChild($target_parent->id)->get();
           $param['target_students'] = $target_students;
-          $param['target_student'] = $target_students->first();
         }elseif($request->has('student_id') && is_numeric($request->get('student_id'))){
-          $param['target_student'] = Student::where('id', $request->get('student_id'))->first();
+          $param['target_students'] = Student::where('id', $request->get('student_id'));
         }else {
           $param['target_students'] = Student::all()->get();
         }

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -178,7 +178,7 @@ class TaskController extends MilestoneController
         $param = $this->get_param($request);
         $item = $this->model()->where('id',$id)->first();
         $param['item'] = $item;
-        $param['target_student'] = Student::where('user_id',$item->target_user_id)->first();
+        $param['target_students'] = Student::where('user_id',$item->target_user_id);
         $param['_edit'] = true;
         return view($this->domain.'.create')->with($param);
     }

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -215,7 +215,7 @@ class TaskController extends MilestoneController
 
         return $this->api_response(200, '', '', $item);
       }, __('messages.info_updated'), __FILE__, __FUNCTION__, __LINE__ );
-      if($this->is_success_response($res)){
+      if($this->is_success_response($res) && $request->get('mail_send') == "yes"){
         $this->sendmail($res);
       }
       return $res;

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -27,4 +27,8 @@ class Message extends Comment
                    ->orWhere('create_user_id',$id);
     }
 
+    public function message_tasks(){
+      return $this->hasMany('App\Models\Task','message_id','id');
+    }
+
 }

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -27,8 +27,16 @@ class Message extends Comment
                    ->orWhere('create_user_id',$id);
     }
 
+    public function scopeFindParentHomeworkRequest($query){
+      return $query->findTypes('homework_request')->has('create_parents');
+    }
+
+    public function create_parents(){
+      return $this->belongsTo('App\Models\StudentParent','create_user_id','user_id');
+    }
+
     public function message_tasks(){
-      return $this->hasMany('App\Models\Task','message_id','id');
+      return $this->hasMany('App\Models\Task','message_id','id')->where('status','<>','cancel');
     }
 
 }

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -37,6 +37,10 @@ class Task extends Milestone
       return $this->belongsTo('App\Models\Milestone', 'milestone_id');
     }
 
+    public function messages(){
+      return $this->belongsTo('App\Models\Message','message_id');
+    }
+
     public function textbooks(){
       return $this->belogsToMany('App\Models\Textbook');
     }

--- a/config/attribute/message_type.php
+++ b/config/attribute/message_type.php
@@ -1,9 +1,6 @@
 <?php
 return array(
-  'information' => '事務連絡',
-  'promotion' => '進学、進級に関して',
-  'examination' => '試験に関して',
-  'study' => '学習に関して',
-  'other' => 'その他',
+  'infomation' => '事務連絡',
+  'homework_request' => '宿題に関する要望',
 );
 ?>

--- a/config/attribute/task_type.php
+++ b/config/attribute/task_type.php
@@ -1,5 +1,6 @@
 <?php
 return array(
+  'home_work' => '宿題',
   'school_grade' => '内部進学',
   'entrance_exam' => '受験',
   'other' => 'その他',

--- a/resources/lang/en/labels.php
+++ b/resources/lang/en/labels.php
@@ -365,4 +365,5 @@ return [
   'task_schedule' => 'schedule',
   'task_remind' => 'notify',
   'notification' => 'notification',
+  'homework_request_list' => 'List from parent\'s requests'
 ];

--- a/resources/lang/ja/labels.php
+++ b/resources/lang/ja/labels.php
@@ -370,5 +370,6 @@ return [
   'task_schedule' => '予定',
   'task_remind' => '通知する',
   'notification' => '通知',
+  'homework_request_list' => '宿題要望一覧'
 
 ];

--- a/resources/views/dashboard/widget/tasks.blade.php
+++ b/resources/views/dashboard/widget/tasks.blade.php
@@ -123,7 +123,7 @@
               <small class="text-muted float-right">
                 <i class="fa fa-clock"></i>
                 {{$item->create_user->details()->name()}}/
-                {{$item->dateweek_format($item->created_at,'Y/m/d')}}  {{date('H:m',strtotime($item->created_at))}}
+                {{$item->dateweek_format($item->created_at,'Y/m/d')}}  {{date('H:i',strtotime($item->created_at))}}
               </small>
             </div>
           </li>

--- a/resources/views/dashboard/widget/tasks.blade.php
+++ b/resources/views/dashboard/widget/tasks.blade.php
@@ -75,6 +75,11 @@
                     @endif
                   </div>
                   <div class="col-12 col-md-4 text-truncate">
+                    @if(!empty($item->message_id))
+                    <span class="badge badge-primary">
+                      <i class="fa fa-inbox"></i>
+                    </span>
+                    @endif
                     <a href="javascript:void(0)" title="{{__('labels.details')}}" page_form="dialog" page_title="{{$item->title}}" page_url="/tasks/{{$item->id}}/detail_dialog" role="button">
                       {{$item->title}}
                     </a>
@@ -97,7 +102,7 @@
                 </div>
               </div>
             </div>
-            <div class="row">
+            <div class="row mt-1">
               <div class="col-12">
                 @component('tasks.components.buttons',[
                   'item' => $item,

--- a/resources/views/messages/create.blade.php
+++ b/resources/views/messages/create.blade.php
@@ -53,14 +53,11 @@
           </div>
         </div>
       @endif
-      <input type="hidden" name="type" value="information">
-      <!--
-      種別は用途が曖昧なためいったん出さない
       <div class ="col-6">
         <label>{{__('labels.message_type')}}</label>
         @if($_reply == false)
         <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
-        <select name="type" class="form-control">
+        <select name="type" name="type" class="form-control" required>
           @foreach($message_type as $key => $value)
             <option value="{{$key}}">{{$value}}</option>
           @endforeach
@@ -70,7 +67,6 @@
         <input type="hidden" name="type" value="{{$item->type}}">
         @endif
       </div>
-    -->
       <div class="col-12 mt-2">
         <div class="form-group">
           <label>{{__('labels.body')}}</label>

--- a/resources/views/messages/list.blade.php
+++ b/resources/views/messages/list.blade.php
@@ -77,6 +77,22 @@
         <!-- 検索 -->
       </div>
     </div>
+    <div class="card-header">
+      <ul class="nav nav-pills ml-auto float-left mb-2">
+        <li class="nav-item mr-1">
+          <a class="nav-link btn btn-sm btn-default" href="/{{$domain}}/{{$item->id}}/messages">
+            <i class="fas fa-globe-asia"></i>
+            {{__('labels.all')}}
+          </a>
+        </li>
+        <li class="nav-item mr-1">
+          <a class="nav-link btn btn-sm btn-default {{$search_type == "parent_homework_request" ? 'active' : ''}}" href="/{{$domain}}/{{$item->id}}/messages?search_type=parent_homework_request">
+            <i class="far fa-clipboard"></i>
+            {{__('labels.homework_request_list')}}
+          </a>
+        </li>
+      </ul>
+    </div>
     <div class="card-body p-0">
       @if(count($items) > 0)
       <ul class="products-list product-list-in-card pl-2 pr-2">
@@ -86,6 +102,12 @@
             <div class="col-6 text-truncate">
               <div class="row">
                 <div class="col-12">
+                  @if($item->message_tasks->count() > 0)
+                      <span class="badge badge-primary">
+                        <i class="fa fa-file-alt"></i>
+                        {{$item->message_tasks()->count()}}
+                      </span>
+                  @endif
                   <a href="javascript:void(0)" page_url="/messages/{{$item->id}}/details" page_title="{{$item->title}}" page_form="dialog" title="{{$item->id}}">
                     {{$item->title}}
                   </a>
@@ -130,13 +152,9 @@
               <div class="row">
                 <div class="col-12">
                   @if($item->type == 'homework_request' && $item->create_user->details()->role == 'parent')
-                  <a href="javascript:void(0);" page_form="dialog" page_url="/tasks/create?message_id={{$item->id}}" page_title="{{__('labels.tasks').__('labels.add_button')}}" class="btn btn-outline-primary btn-sm float-left {{$item->message_tasks->count() > 0 ? 'disabled' : ''}}" >
-                    <i class="fa fa-{{$item->message_tasks->count() > 0 ? 'check' : 'plus'}} mr-1"></i>
+                  <a href="javascript:void(0);" page_form="dialog" page_url="/tasks/create?message_id={{$item->id}}" page_title="{{__('labels.tasks').__('labels.add_button')}}" class="btn btn-outline-primary btn-sm float-left" >
+                    <i class="fa fa-plus" mr-1"></i>
                     {{__('labels.tasks').__('labels.add_button')}}
-                    @if($item->message_tasks->count() > 0)
-                        <span class="badge badge-primary">{{$item->message_tasks()->count()}}</span>
-                      </a>
-                    @endif
                   </a>
                   @endif
 

--- a/resources/views/messages/list.blade.php
+++ b/resources/views/messages/list.blade.php
@@ -129,6 +129,17 @@
             <div class="col-12">
               <div class="row">
                 <div class="col-12">
+                  @if($item->type == 'homework_request' && $item->create_user->details()->role == 'parent')
+                  <a href="javascript:void(0);" page_form="dialog" page_url="/tasks/create?message_id={{$item->id}}" page_title="{{__('labels.tasks').__('labels.add_button')}}" class="btn btn-outline-primary btn-sm float-left {{$item->message_tasks->count() > 0 ? 'disabled' : ''}}" >
+                    <i class="fa fa-{{$item->message_tasks->count() > 0 ? 'check' : 'plus'}} mr-1"></i>
+                    {{__('labels.tasks').__('labels.add_button')}}
+                    @if($item->message_tasks->count() > 0)
+                        <span class="badge badge-primary">{{$item->message_tasks()->count()}}</span>
+                      </a>
+                    @endif
+                  </a>
+                  @endif
+
                   @if($enable_create)
                   <a href="javascript:void(0);" page_form="dialog" page_url="/messages/{{$item->id}}/reply" page_title="{{__('labels.reply')}}" class="btn btn-primary btn-sm float-right">
                     <i class="fa fa-reply mr-1"></i>{{__('labels.reply')}}

--- a/resources/views/tasks/create.blade.php
+++ b/resources/views/tasks/create.blade.php
@@ -76,7 +76,8 @@
         </div>
       </div>
       <div class="collapse" id="setting_details">
-        <div class="row mt-2 collpase" id="setting_details">
+        <div class="row mt-2 collpase">
+          @if($target_students->count() == 1)
           <div class="col-6">
             <label>{{__('labels.milestones')}}</label>
             <span class="right badge badge-secondary ml-1">{{__('labels.optional')}}</span>
@@ -87,6 +88,7 @@
               @endforeach
             </select>
           </div>
+          @endif
           @if($_edit)
           <div class="col-6">
             <label>{{__('labels.status')}}</label>
@@ -111,12 +113,12 @@
           <div class="col-6">
             <label>{{__('labels.start_schedule')}}</label>
             <span class="right badge badge-secondary ml-1">{{__('labels.optional')}}</span>
-            <input type="text" name="start_schedule" class="form-control" uitype="datepicker" minvalue="{{date('Y/m/d')}}"   placeholder=""  value="{{$_edit ? $item->start_schedule : ""}}">
+            <input type="text" name="start_schedule" class="form-control" uitype="datepicker" minvalue="{{date('Y/m/d')}}"   placeholder=""  value="{{$_edit ? date('Y/m/d', strtotime($item->start_schedule)) : ""}}">
           </div>
           <div class="col-6">
             <label>{{__('labels.end_schedule')}}</label>
             <span class="right badge badge-secondary ml-1">{{__('labels.optional')}}</span>
-            <input type="text" name="end_schedule" class="form-control" uitype="datepicker" minvalue="{{date('Y/m/d')}}" placeholder=""  value="{{$_edit ? $item->end_schedule : "" }}">
+            <input type="text" name="end_schedule" class="form-control" uitype="datepicker" minvalue="{{date('Y/m/d')}}" placeholder=""  value="{{$_edit ?  date('Y/m/d', strtotime($item->end_schedule)) : "" }}">
           </div>
         </div>
         <div class="row mt-2">

--- a/resources/views/tasks/create.blade.php
+++ b/resources/views/tasks/create.blade.php
@@ -39,7 +39,7 @@
         @endforeach
       </select>
       @else
-      <input type="hidden" name="target_user_id" value="{{$target_student->user_id}}">
+      <input type="hidden" name="target_user_id" value="{{$target_students->first()->user_id}}">
       @endif
       <div class="row mt-2">
         <div class="col-12">
@@ -82,7 +82,7 @@
             <span class="right badge badge-secondary ml-1">{{__('labels.optional')}}</span>
             <select name="milestone_id" class="form-control select2" width="100%">
               <option value=" ">{{__('labels.selectable')}}</option>
-              @foreach($target_student->target_milestone as $milestone)
+              @foreach($target_students->first()->target_milestone as $milestone)
                 <option value="{{$milestone->id}}" {{$_edit && $milestone->id == $item->milestone_id ? 'selected ': ''}}>{{$milestone->title}}</option>
               @endforeach
             </select>

--- a/resources/views/tasks/create.blade.php
+++ b/resources/views/tasks/create.blade.php
@@ -7,7 +7,40 @@
     <form method="POST" action="/tasks" id="create_task_form" enctype="multipart/form-data">
     @endif
       @csrf
+      @if(!empty($message))
+      <input type="hidden" name="message_id" value="{{$message->id}}">
+      <div class="row">
+        <div class="col-12">
+          <h3 class="card-title">
+            <label>
+            {{__('labels.original_message')}}
+            </label>
+             <button type="button" class="btn btn-tool" data-toggle="collapse" data-target="#original_message"><i class="fas fa-plus"></i></button>
+          </h3>
+        </div>
+      </div>
+      <div class="collapse"  id="original_message">
+        <div class="row mt-2 collpase">
+          <div class="col-12">
+            <label>{{$message->title}}</label>
+            <div class="form-group">
+              {!!nl2br($message->body)!!}
+            </div>
+          </div>
+        </div>
+      </div>
+      @endif
+      @if($target_students->count() > 1)
+      <label>{{__('labels.target_user')}}</label>
+      <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
+      <select name="target_user_id" class="form-control"  required="true">
+        @foreach($target_students as $student)
+        <option value="{{$student->user_id}}">{{$student->details()->name()}}</option>
+        @endforeach
+      </select>
+      @else
       <input type="hidden" name="target_user_id" value="{{$target_student->user_id}}">
+      @endif
       <div class="row mt-2">
         <div class="col-12">
           <label>{{__('labels.title')}}</label>
@@ -141,3 +174,26 @@
       </div>
     </form>
   </div>
+  <script>
+  function get_milestones(){
+    var student_id = ($('name=student_id').val())|0
+    service.getAjax(false,'/tasks/get_milestones?student_id='+student_id, milestones,
+      function(result,st,xhr){
+        if(result['status']===200){
+          //ここに成功時の処理
+          var student_id_form = $("select[name='milestone_id']");
+          student_id_form.empty();
+          student_id_form.select2('destroy');
+          $.each(reult['data'], function(id,val){
+            var _option = '<option value="'+id+'">'+val+'</option>'
+          })
+          $()
+        }
+      }、
+      function(xhr,st,err){
+        messageCode = "error";
+        messageParam= "\n"+err.message+"\n"+xhr.responseText;
+        alert("システムエラーが発生しました\n"+messageParam);
+      });
+  }
+  </script>


### PR DESCRIPTION
issue374
契約者→講師　要望
講師　タスク登録

契約者からの要望をもとにタスクを登録する必があるため、
”メッセージから要望を受け取り、タスクを登録する機能”
を追加した

messagesにtypeを追加
　事務連絡
　宿題に関する要望

tasksのtypeを追加
　宿題

メッセージを"宿題に関する希望”で契約者が送信する
　講師、契約者両方がメッセージの一覧からタスクの登録ができるようになる
　　兄弟がいない場合
　　　通常のタスク登録と同様
　　兄弟がいる場合
　　　タスクの対象者がselectで選べる
　　　目標が入力できない
　メッセージからタスクの登録を行うとメッセージにfile-altのバッジがつく
　　そのメッセージから作られたタスクの数が表示される
　タスク側ではメッセージから生成されたタスクはタイトルの前にinboxアイコンがつく
 
メッセージ一覧で簡易フィルター追加
　宿題要望一覧を押すと、タスク追加が行えるメッセージの一覧が見られる
　　タスク追加が行えるのは以下を満たしたメッセージ
　　　・create_userがparentsである
　　　・typeがhomework_requestである
　　返信でも条件を満たせばタスク追加可能なので、やり取りが長くなるとボタンがたくさん表示される