### PR TITLE
カレンダー設定：設定終了日が空で更新されない

### DIFF
--- a/app/Http/Controllers/UserCalendarSettingController.php
+++ b/app/Http/Controllers/UserCalendarSettingController.php
@@ -293,6 +293,7 @@ class UserCalendarSettingController extends UserCalendarController
           $form['students'][] = $student;
         }
       }
+      
       return $form;
     }
 

--- a/app/Models/UserCalendarSetting.php
+++ b/app/Models/UserCalendarSetting.php
@@ -342,7 +342,7 @@ EOT;
     $data = [];
 
     if(array_key_exists('enable_end_date', $form)){
-      $data['enable_end_date'] = '';
+      $data['enable_end_date'] = null;
     }
 
     foreach($update_fields as $field){

--- a/app/Models/UserCalendarSetting.php
+++ b/app/Models/UserCalendarSetting.php
@@ -340,11 +340,15 @@ EOT;
     }
     $form['lecture_id'] = $lecture_id;
     $data = [];
+
+    if(array_key_exists('enable_end_date', $form)){
+      $data['enable_end_date'] = '';
+    }
+
     foreach($update_fields as $field){
       if(!isset($form[$field])) continue;
       $data[$field] = $form[$field];
     }
-
     if(isset($data['from_time_slot']) && isset($data['to_time_slot'])){
       //course_minutesは、time_slotから補完
       $data['course_minutes'] = intval(strtotime('2000-01-01 '.$data['to_time_slot']) - strtotime('2000-01-01 '.$data['from_time_slot']))/60;

--- a/resources/views/calendar_settings/remind.blade.php
+++ b/resources/views/calendar_settings/remind.blade.php
@@ -1,9 +1,11 @@
 @component('calendar_settings.page', ['item' => $item, 'fields' => $fields, 'domain' => $domain, 'action'=>'', 'user'=>$user])
   @slot('page_message')
   @if($item['status']==='confirm')
-  生徒あてに通常授業予定確認をを再送します。
+  生徒あてに通常授業予定確認をを連絡します。
   @elseif($item['status']==='fix')
-  生徒、講師あてに通常授業予定を再送します。
+  生徒、講師あてに通常授業予定を連絡します。
+  @elseif($item['status']==='new')
+  講師あてに通常授業予定を連絡します。
   @endif
   @endslot
   @slot('forms')
@@ -20,7 +22,7 @@
       <div class="col-12 col-md-6 mb-1">
           <button type="button" class="btn btn-submit btn-danger btn-block"  accesskey="{{$domain}}_action" confirm="{{__('messages.confirm_calendar_remind')}}">
             <i class="fa fa-envelope mr-1"></i>
-              {{__('labels.remind_button')}}
+              {{__('labels.send_button')}}
           </button>
       </div>
       <div class="col-12 col-md-6 mb-1">

--- a/resources/views/calendars/remind.blade.php
+++ b/resources/views/calendars/remind.blade.php
@@ -1,11 +1,11 @@
 @component('calendars.page', ['item' => $item, 'fields' => $fields, 'domain' => $domain, 'action'=>'', 'user'=>$user])
   @slot('page_message')
   @if($item['status']==='rest')
-  講師あてに休み連絡を再送します。
+  講師あてに休み連絡を連絡します。
   @elseif($item['status']==='confirm')
-  生徒あてに授業予定確認をを再送します。
+  生徒あてに授業予定確認をを連絡します。
   @elseif($item['status']==='fix')
-  生徒、講師あてに授業予定を再送します。
+  生徒、講師あてに授業予定を連絡します。
   @endif
   @endslot
   @slot('forms')
@@ -22,7 +22,7 @@
       <div class="col-12 col-md-6 mb-1">
           <button type="button" class="btn btn-submit btn-danger btn-block"  accesskey="{{$domain}}_action" confirm="{{__('messages.confirm_calendar_remind')}}">
             <i class="fa fa-envelope mr-1"></i>
-              {{__('labels.remind_button')}}
+              {{__('labels.send_button')}}
           </button>
       </div>
       <div class="col-12 col-md-6 mb-1">

--- a/resources/views/trials/forms/user_calendar_setting.blade.php
+++ b/resources/views/trials/forms/user_calendar_setting.blade.php
@@ -54,7 +54,7 @@
           <i class="fa fa-calendar-minus"></i>
         </a>
         @elseif($setting->status=='new')
-        <a href="javascript:void(0);" page_form="dialog" page_url="/calendar_settings/{{$setting->id}}/status_update/confirm" page_title="確認連絡" role="button" class="btn btn-sm btn-warning ml-1">
+        <a href="javascript:void(0);" page_form="dialog" page_url="/calendar_settings/{{$setting->id}}/status_update/remind" page_title="確認連絡" role="button" class="btn btn-sm btn-warning ml-1">
           <i class="fa fa-envelope"></i>
         </a>
         @endif


### PR DESCRIPTION
体験からのカレンダー連絡が確認操作にならないようにする

①確認
体験授業＞詳細＞status=newの通常授業のメールボタン
![image](https://user-images.githubusercontent.com/22382436/83114728-51a60f80-a104-11ea-8e3a-942afe5c6657.png)
連絡のダイアログから送信ボタン
★以下2点を確認
　・statsu=confirmにならないこと
　・メールが講師にのみ送信される
（通常授業登録がありステータス：newのものがある体験申し込みを使うとよい）
https://sakuraone.jp/trials/41

②確認
通常授業設定の編集にて、
授業終了日を空で更新できること
