### PR TITLE
更新部分の同期

### DIFF
--- a/database/seeds/CalendarRecoverySeeder.php
+++ b/database/seeds/CalendarRecoverySeeder.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 use App\Models\UserCalendar;
 use App\Models\UserCalendarMember;
 use App\Http\Controllers\Controller;
@@ -24,79 +25,148 @@ class CalendarRecoverySeeder extends Seeder
 
       $this->delete_calendar_sync($d);
       $this->post_calendar_sync();
+      $this->put_calendar_sync();
     }
     public function delete_calendar_sync($d){
       $controller = new Controller;
       $request = new Illuminate\Http\Request;
 
       $del_url = config('app.management_url').'/sakura-api/api_delete_onetime_schedule.php';
-
+      //schedule_idを持つ、memberがない　→　onetime側も削除
       foreach($d as $data){
         $member = UserCalendarMember::where('schedule_id' , $data["id"])->first();
         if(!isset($member)){
-          echo "del:".$data["id"];
           $res = $controller->call_api($request, $del_url, "POST", ["id" => $data["id"], "updateuser" => "1"]);
         }
       }
     }
     public function put_calendar_sync(){
-      $calendars = UserCalendar::rangeDate('2020-04-01', '2020-07-01')->get();
-      foreach($calendars as $calendar){
-        foreach($calendar->members as $member){
-          if($member->schedule_id>0){
-            switch($calendar->work){
-              case 6:
-              case 7:
-              case 8:
-                $rest_type = "";
-                $rest_result="";
-                if($calendar->is_rest_status($calendar->status)==true){
-                  $rest_type = $member->rest_type;
-                  $rest_result = $member->rest_result;
-                }
-                $res = $member->office_system_api('PUT', $rest_type, $rest_result);
-                break;
-              default:
-                $res = $member->office_system_api('PUT');
-                break;
-            }
-          }
-        }
+      $sql = <<<EOT
+        select
+        concat(t1.id, ':', t1.name_last, t1.name_first) as t_name
+        , concat(t2.id, ':', t2.name_last, t2.name_first) as m_name
+        , u.id as calendar_id
+        , u.start_time
+        , u.end_time
+        , u.status
+        , u.work
+        , u.exchanged_calendar_id
+        , (select schedule_id from user_calendar_members a where a.calendar_id = u.exchanged_calendar_id limit 1) as exchanged_schedule_id
+        , m.id as member_id
+        , m.user_id
+        , m.status
+        , m.rest_type
+        , m.rest_result
+        , m.exchange_limit_date
+        , o.id as schedule_onetime_id
+        , o.confirm
+        , o.cancel
+        , o.cancel_reason
+        from user_calendars u
+        inner join user_calendar_members m  on u.id = m.calendar_id
+        left outer join hachiojisakura_calendar.tbl_schedule_onetime o  on m.schedule_id = o.id
+        left outer join common.teachers t1 on t1.user_id = u.user_id
+        left outer join common.managers t2 on t2.user_id = u.user_id
+EOT;
+        //出席ステータスの同期
+        $_sql = $sql." where u.status='presence' and m.status='presence' and o.confirm!='f'";
+        $d = DB::select($_sql);
+        $this->update_schedule_ontime('f', '', $d);
+
+        //キャンセルステータスの同期
+        $_sql = $sql." where u.status='cancel' and m.status='cancel' and o.cancel!='c'";
+        $_sql .= " and m.user_id in(select user_id from common.students)";
+        $d = DB::select($_sql);
+        $this->update_schedule_ontime('', 'c', $d);
+
+        //a1ステータスの同期
+        $_sql = $sql." where m.status='rest' and m.rest_type='a1' and o.cancel!='a1'";
+        $_sql .= " and m.user_id in(select user_id from common.students)";
+        $d = DB::select($_sql);
+        $this->update_schedule_ontime('', 'a1', $d);
+
+        //a2ステータスの同期
+        $_sql = $sql." where m.status='rest' and m.rest_type='a2' and o.cancel!='a2'";
+        $_sql .= " and m.user_id in(select user_id from common.students)";
+        $d = DB::select($_sql);
+        $this->update_schedule_ontime('', 'a2', $d);
+
+        //aステータスの同期(事務の休み)
+        $_sql = $sql." where u.status='rest' and u.work=9 and o.cancel!='a'";
+        $d = DB::select($_sql);
+        $this->update_schedule_ontime('', 'a', $d);
+
+        //振替idを取った場合の同期
+        $_sql = $sql." where u.exchanged_calendar_id=0 and o.altsched_id>0";
+        $d = DB::select($_sql);
+        $this->exchanged_calendar_id_clear($d);
+
+        //振替idをつけた場合の同期
+        $_sql = $sql." where u.exchanged_calendar_id>0 and o.altsched_id=0";
+        $d = DB::select($_sql);
+        $this->exchanged_calendar_id_set($d);
+
+        //2020.4-2020.5の振替期限は、2020-12-31
+        $this->update_exchange_limit_date_20201231();
+    }
+    public function update_schedule_ontime($confirm, $cancel, $d){
+      $id = [];
+      foreach($d as $row){
+        $id[] = $row->schedule_onetime_id;
+      }
+      if(count($id)==0) return;
+      DB::table('hachiojisakura_calendar.tbl_schedule_onetime')->whereIn('id', $id)->update([
+        'confirm' => $confirm,
+        'cancel' => $cancel,
+      ]);
+
+    }
+    public function update_exchange_limit_date_20201231(){
+      DB::table('lms.user_calendar_members')->where('exchange_limit_date','>','2020-03-26')
+                                            ->whereRaw("calendar_id in (select id from user_calendars where start_time between '2020-04-01 00:00:00' and '2020-06-01 00:00:00')", [])
+                                            ->update([
+                                              'exchange_limit_date' => '2020-12-31'
+                                            ]);
+    }
+    public function exchanged_calendar_id_clear($d){
+      $id = [];
+      foreach($d as $row){
+        $id[] = $row->schedule_onetime_id;
+      }
+      if(count($id)==0) return;
+      DB::table('hachiojisakura_calendar.tbl_schedule_onetime')->whereIn('id', $id)->update([
+        'altsched_id' => 0
+      ]);
+    }
+    public function exchanged_calendar_id_set($d){
+      $id = [];
+      foreach($d as $row){
+        DB::table('hachiojisakura_calendar.tbl_schedule_onetime')->where('id', $row->schedule_onetime_id)->update([
+          'altsched_id' => $row->exchanged_schedule_id
+        ]);
       }
     }
     public function post_calendar_sync(){
       $controller = new Controller;
       $message = "";
-      $calendars = UserCalendar::whereNotIn('work' , [11,12])->get();
-      foreach($calendars as $calendar){
-        $schedule_id = 0;
-        foreach($calendar->members as $member){
-          if($member->schedule_id > 0){
-            $schedule_id = $member->schedule_id;
-          }
-        }
-        if($schedule_id==0){
-          echo "calendar_id=".$calendar->id."\n";
-          foreach($calendar->members as $member){
-            if($member->schedule_id==0){
-              switch($calendar->work){
-                case 3:
-                case 4:
-                case 5:
-                case 6:
-                case 7:
-                case 8:
-                  if($member->user_id != $calendar->user_id){
-                    $res = $member->office_system_api('POST');
-                  }
-                  break;
-                default:
-                  $res = $member->office_system_api('POST');
-                  break;
-              }
+      $members = UserCalendarMember::with('calendar')->where('schedule_id', '<', 1)->whereRaw('calendar_id in (select id from lms.user_calendars where work not in (11,12))',[])->get();
+      foreach($members as $member){
+        switch($member->calendar->work){
+          case 3:
+          case 4:
+          case 5:
+          case 6:
+          case 7:
+          case 8:
+            if($member->user_id != $member->calendar->user_id){
+              $res = $member->office_system_api('POST');
             }
-          }
+            break;
+          default:
+            $res = $member->office_system_api('POST');
+            break;
         }
       }
+
     }
 }

--- a/database/seeds/CalendarRecoverySeeder.php
+++ b/database/seeds/CalendarRecoverySeeder.php
@@ -75,7 +75,6 @@ EOT;
 
         //キャンセルステータスの同期
         $_sql = $sql." where u.status='cancel' and m.status='cancel' and o.cancel!='c'";
-        $_sql .= " and m.user_id in(select user_id from common.students)";
         $d = DB::select($_sql);
         $this->update_schedule_ontime('', 'c', $d);
 

--- a/resources/views/calendars/page.blade.php
+++ b/resources/views/calendars/page.blade.php
@@ -56,9 +56,12 @@
         <small class="badge badge-primary mt-1 mr-1 p-1">
           <i class="fa fa-exchange-alt mr-1"></i>
           {{__('labels.exchange')}}: <span id="exchanged_calendar_datetime">
+            @if(isset($item->exchanged_calendar))
             {{$item->exchanged_calendar->details()["datetime"]}}
+            @endif
           </span>
         </small>
+        @else
         @endif
         <br>
 


### PR DESCRIPTION
具体的には、以下3つのテーブルについて、
lms.user_calendars u
lms.user_calendars um
tbl_schedule_ontime so
u : um (予定：参加者＝生徒）でジョインしたものが、so相当になり、
um.status / um.rest_type / um.rest_result
 →　so.confirm / so.cancel / so.cancel_reason　との状態合わせを行います。
um.schedule_id = so.idでリレーションするようになっています。


----------------------
①restの場合(生徒付けのumを操作する）
u.status  .... 様々
um.status=rest
um.rest_type=a1 or a2
um.rest_result = 主に休講
so.confirm = ''
so.cancel = um.rest_type
so.cancel_reason = um.rest_result
-----------------------
②presenceの場合
u.status  =presence
um.status=presence
um.rest_type=''
um.rest_result = ''
so.confirm = f
so.cancel = ''
so.cancel_reason = ''
----------------------
③cancelの場合
u.status=cancel
um.status=cancel
so.confirm=''
so.cancel=c
----------------------
④事務の休みの場合
u.status=rest
u.work = 9 (事務)
so.cancel=a
----------------------
⑤user_calendarsの振替IDがない場合
　→　altsched_id = 0にする
----------------------
⑥user_calendarsの振替IDをつけた場合
　→　altsched_id を振り替えたcalendar_id相当の、schedule_idをセットする
----------------------
⑦2020/4/1 - 2020/5/31の振替期限を2020/12/31にする