### PR TITLE
修正１件、拡張１件

### DIFF
--- a/app/Models/UserCalendar.php
+++ b/app/Models/UserCalendar.php
@@ -1273,7 +1273,7 @@ EOT;
       }
     }
     if($this->status != $status){
-      UserCalendar::where('id', $this->id)->update(['status' => $status]);
+      $this->update(['status' => $status]);
     }
   }
 }

--- a/app/Models/UserCalendarSetting.php
+++ b/app/Models/UserCalendarSetting.php
@@ -613,7 +613,7 @@ EOT;
 
     $schedules = $this->get_add_calendar_date($start_date, $end_date, $range_month, $month_week_count);
     foreach($schedules as $date => $already_calendar){
-      if(isset($already_calendar) && count($already_calendar)>0){
+      if(isset($already_calendar['already_calendars']) && count($already_calendar['already_calendars'])>0){
         //作成済みの場合
         continue;
       }
@@ -709,6 +709,23 @@ EOT;
       $calendar->update(['status' => $default_status]);
     }
     return $this->api_response(200, "", "", $calendar);
+  }
+  public function set_status(){
+    parent::set_status();
+    if($this->status=='fix'){
+      $start_date = $this->enable_start_date;
+      $end_date = $this->enable_end_date;
+      if(strtotime($start_date) < strtotime(date('Y-m-1'))){
+        //今月1日より以前なら、今月1日を登録開始にする
+        $start_date = date('Y-m-1');
+      }
+      if(empty($end_date)){
+        //設定がないなら来月末
+        $end_date = date('Y-m-t', strtotime('+1 month'));
+      }
+      \Log::warning("mogumogu(".$start_date.":".$end_date.")");
+      $this->setting_to_calendar($start_date, $end_date, 1, 5);
+    }
   }
 
 }

--- a/resources/views/calendars/create_form.blade.php
+++ b/resources/views/calendars/create_form.blade.php
@@ -1,7 +1,7 @@
 @section('first_form')
 <div class="row">
   @if($item->work!=9)
-    @if($item->trial_id == 0 && $item["exchanged_calendar_id"]==0)
+    @if($item->trial_id == 0 && $item["exchanged_calendar_id"]==0 && $_edit==false)
     <div class="col-12">
       <div class="alert alert-warning text-sm pr-2 schedule_type schedule_type_class">
         <h5><i class="icon fa fa-exclamation-triangle"></i> {{__('labels.important')}}</h5>


### PR DESCRIPTION
・予定編集時に授業追加の警告メッセージを表示しない
・カレンダー設定がfixになったタイミングで、calendarを当月＋来月末追加する（競合予定があれば追加しない）

〇動作確認
講師詳細＞勤務実績＞予定の編集
　→　授業追加の警告メッセージを表示しない

講師詳細＞通常授業一覧＞設定追加
　講師詳細＞通常授業設定一覧（確認）＞確認連絡
　　生徒の確認を必要としない
　→　あわせて、その設定によりcalendarを当月＋来月末追加する