### PR TITLE
Feature/427

### DIFF
--- a/app/Http/Controllers/CurriculumController.php
+++ b/app/Http/Controllers/CurriculumController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Models\Curriculum;
 use App\Models\Subject;
+use App\Models\Task;
 use Illuminate\Support\Facades\Auth;
 
 
@@ -192,8 +193,12 @@ class CurriculumController extends MilestoneController
 
     public function get_select_list(Request $request){
       $param = $this->get_param($request);
+      if(!empty($request->get('task_id'))){
+        $param['item'] = Task::find($request->get('task_id'));
+      }
       $curriculums = $this->model()->searchBySubjectId($request->get('subject_id'))->get();
       $param['curriculums'] = $curriculums;
+      $param['_edit'] = true;
       return view('curriculums.components.select_list')->with($param);
     }
 }

--- a/app/Http/Controllers/CurriculumController.php
+++ b/app/Http/Controllers/CurriculumController.php
@@ -180,4 +180,11 @@ class CurriculumController extends MilestoneController
       }, '削除しました。', __FILE__, __FUNCTION__, __LINE__ );
       return $res;
     }
+
+    public function get_select_list(Request $request){
+      $param = $this->get_param($request);
+      $curriculums = $this->model()->searchBySubjectId($request->get('subject_id'))->get();
+      $param['curriculums'] = $curriculums;
+      return view('curriculums.components.select_list')->with($param);
+    }
 }

--- a/app/Http/Controllers/CurriculumController.php
+++ b/app/Http/Controllers/CurriculumController.php
@@ -181,6 +181,15 @@ class CurriculumController extends MilestoneController
       return $res;
     }
 
+    public function name_check(Request $request, $name){
+      $item = Curriculum::where('name', $name)->SearchBySubjectId($request->get('subject_id'))->first();
+      if(isset($item)){
+        $json = $this->api_response(200,"","",["name"=>$name]);
+        return $this->send_json_response($json);
+      }
+      return $this->send_json_response($this->notfound());
+    }
+
     public function get_select_list(Request $request){
       $param = $this->get_param($request);
       $curriculums = $this->model()->searchBySubjectId($request->get('subject_id'))->get();

--- a/app/Http/Controllers/CurriculumController.php
+++ b/app/Http/Controllers/CurriculumController.php
@@ -24,7 +24,6 @@ class CurriculumController extends MilestoneController
     public function index(Request $request)
     {
         //
-        $this->authorize('view',new Curriculum);
         $param = $this->get_param($request);
         $items = $this->model()->search($request)->paginate($param['_line']);
 
@@ -35,7 +34,7 @@ class CurriculumController extends MilestoneController
     }
 
     public function create(Request $request){
-     $this->authorize('create',new Curriculum);
+
       $param = $this->get_param($request);
       $subjects = Subject::all();
       $param['subjects'] = $subjects;
@@ -53,7 +52,7 @@ class CurriculumController extends MilestoneController
     public function _store(Request $request)
     {
         //
-        $this->authorize('create',new Curriculum);
+
         $form = $this->create_form($request);
         $item = $this->model();
         foreach($form as $key=>$val){
@@ -91,7 +90,6 @@ class CurriculumController extends MilestoneController
     {
         //
         $param = $this->get_param($request, $id);
-        $this->authorize('view',$param['item']);
         return view($this->domain.'.details')->with($param);
     }
 
@@ -103,7 +101,6 @@ class CurriculumController extends MilestoneController
      */
      public function edit(Request $request, $id)
      {
-       $this->authorize('update',new Curriculum);
        $param = $this->get_param($request, $id);
        $subjects = Subject::all();
        $param['subjects'] = $subjects;
@@ -120,7 +117,6 @@ class CurriculumController extends MilestoneController
      */
      public function _update(Request $request, $id)
      {
-       $this->authorize('update',new Curriculum);
        $res = $this->save_validate($request);
        if(!$this->is_success_response($res)){
          return $res;
@@ -165,14 +161,12 @@ class CurriculumController extends MilestoneController
      */
 
      public function delete(Request $request, $id){
-       $this->authorize('delete',new Curriculum);
        $param = $this->get_param($request,$id);
        return view($this->domain.'.delete')->with($param);
      }
 
     public function _delete(Request $request, $id)
     {
-      $this->authorize('delete',new Curriculum);
       $form = $request->all();
       $res = $this->transaction($request, function() use ($request, $form, $id){
         $item = $this->model()->find($id);

--- a/app/Http/Controllers/StudentController.php
+++ b/app/Http/Controllers/StudentController.php
@@ -383,10 +383,10 @@ class StudentController extends UserController
     //$tasks = $this->task_search($request, $target_user->user_id)->paginate($this->pagenation_line);
     $tasks = $this->task_search($request, $target_user->user_id)->get();
     $param['status_count'] = $target_user->get_target_task_count();
-   return view($this->domain.'.'.$view, [
-     'item' => $item,
-     'tasks' => $tasks,
-   ])->with($param);
+     return view($this->domain.'.'.$view, [
+       'item' => $item,
+       'tasks' => $tasks,
+     ])->with($param);
   }
 
 

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -8,6 +8,7 @@ use App\Models\TaskComment;
 use App\Models\Review;
 use App\Models\Student;
 use App\Models\Curriculum;
+use App\Models\Subject;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 
@@ -43,6 +44,7 @@ class TaskController extends MilestoneController
         $user = $this->login_details($request);
         $param['target_student'] = Student::where('id', $request->get('student_id'))->first();
         $param['curriculums'] = Curriculum::all();
+        $param['subjects'] = Subject::all();
         $param['_edit'] = false;
         $param['task_type'] = $request->get('task_type');
         return view($this->domain . '.create',$param);

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -74,6 +74,16 @@ class TaskController extends MilestoneController
         }
         $res = $this->transaction($request, function() use ($request, $form){
           $item = $this->model()->create($form);
+          if( !empty($request->get('new_curriculums')) ){
+            foreach( $request->get('new_curriculums') as $curriculum_name){
+              $curriculum = Curriculum::create([
+                'name' => $curriculum_name,
+                'create_user_id' => Auth::user()->id,
+              ]);
+              $curriculum->subjects()->attach($request->get('subject_id'));
+              $item->curriculums()->attach($curriculum->id);
+            }
+          }
           $item->curriculums()->attach($request->get('curriculum_ids'));
           if($request->hasFile('upload_file')){
             if ($request->file('upload_file')->isValid([])) {
@@ -106,6 +116,7 @@ class TaskController extends MilestoneController
        return $res;
      }
 
+
     public function create_form(Request $request){
       $user = $this->login_details($request);
       $form = [];
@@ -118,6 +129,7 @@ class TaskController extends MilestoneController
       }else{
         $form['status'] = 'new';
       }
+
       $form['target_user_id'] = $request->get('target_user_id');
       $form['create_user_id'] = $user->user_id;
       $form['start_schedule'] = $request->get('start_schedule');
@@ -180,6 +192,7 @@ class TaskController extends MilestoneController
         $param['_edit'] = true;
         $param['task_type'] = $request->get('task_type');
         $param['curriculums'] = Curriculum::all();
+        $param['subjects'] = Subject::all();
         return view($this->domain.'.create')->with($param);
     }
 

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -75,14 +75,7 @@ class TaskController extends MilestoneController
         $res = $this->transaction($request, function() use ($request, $form){
           $item = $this->model()->create($form);
           if( !empty($request->get('new_curriculums')) ){
-            foreach( $request->get('new_curriculums') as $curriculum_name){
-              $curriculum = Curriculum::create([
-                'name' => $curriculum_name,
-                'create_user_id' => Auth::user()->id,
-              ]);
-              $curriculum->subjects()->attach($request->get('subject_id'));
-              $item->curriculums()->attach($curriculum->id);
-            }
+            $this->create_curriculum($request,$item);
           }
           $item->curriculums()->attach($request->get('curriculum_ids'));
           if($request->hasFile('upload_file')){
@@ -96,6 +89,17 @@ class TaskController extends MilestoneController
           $this->sendmail($res);
         }
         return $res;
+     }
+
+     public function create_curriculum(Request $request, $item){
+       foreach( $request->get('new_curriculums') as $curriculum_name){
+         $curriculum = Curriculum::create([
+           'name' => $curriculum_name,
+           'create_user_id' => Auth::user()->id,
+         ]);
+         $curriculum->subjects()->attach($request->get('subject_id'));
+         $item->curriculums()->attach($curriculum->id);
+       }
      }
 
      public function sendmail($res){
@@ -225,6 +229,9 @@ class TaskController extends MilestoneController
           }
         }
         $item->change($form, $file, $is_file_delete,$request->get('curriculum_ids'));
+        if( !empty($request->get('new_curriculums')) ){
+          $this->create_curriculum($request,$item);
+        }
 
         return $this->api_response(200, '', '', $item);
       }, __('messages.info_updated'), __FILE__, __FUNCTION__, __LINE__ );

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -55,7 +55,7 @@ class Task extends Milestone
         }elseif($search_type == "class_record"){
           $statuses = ["done"];
         }else{
-          $statuses = ['new','progress'];
+          $statuses = ['new','progress','done'];
         }
         $query = $query->activeTasks($statuses);
       }else{

--- a/resources/lang/en/labels.php
+++ b/resources/lang/en/labels.php
@@ -372,5 +372,6 @@ return [
   'homework' => 'Homeworks',
   'class_record' => 'Class records',
   'task_understanding' => 'Understanding',
-    'created_date' => 'Created Date',
+  'created_date' => 'Created Date',
+  'learning_record' => 'Learning Records',
 ];

--- a/resources/lang/ja/labels.php
+++ b/resources/lang/ja/labels.php
@@ -379,4 +379,5 @@ return [
   'class_record' => '授業記録',
   'task_understanding' => '理解度',
   'created_date' => '起票日',
+  'learning_record' => '学習記録',
 ];

--- a/resources/views/curriculums/components/select_list.blade.php
+++ b/resources/views/curriculums/components/select_list.blade.php
@@ -1,0 +1,11 @@
+    <label>{{__('labels.curriculums_name')}}</label>
+    <span class="right badge badge-secondary ml-1">{{__('labels.optional')}}</span>
+    <select name="curriculum_ids[]" class="form-control select2" id="curriculum_select" width=100%  multiple="multiple">
+      @foreach($curriculums as $curriculum)
+      <option value="{{$curriculum->id}}"
+      @if(!empty($item) && $_edit)
+        {{$item->curriculums->contains($curriculum->id)  ? "selected" : "" }}
+      @endif
+      >{{$curriculum->name}}</option>
+      @endforeach
+    </select>

--- a/resources/views/curriculums/components/select_list.blade.php
+++ b/resources/views/curriculums/components/select_list.blade.php
@@ -1,6 +1,9 @@
     <label>{{__('labels.curriculums_name')}}</label>
     <span class="right badge badge-secondary ml-1">{{__('labels.optional')}}</span>
-    <select name="curriculum_ids[]" class="form-control select2" id="curriculum_select" width=100%  multiple="multiple">
+    <a href="javascript:void(0);" id="add_curriculum" class="btn btn-default btn-sm ml-1" title="{{__('labels.curriculums').__('labels.add_button')}}">
+      <i class="fa fa-plus"></i>
+    </a>
+    <select name="curriculum_ids[]" class="form-control select2" id="select_curriculum" width=100%  multiple="multiple">
       @foreach($curriculums as $curriculum)
       <option value="{{$curriculum->id}}"
       @if(!empty($item) && $_edit)
@@ -9,3 +12,9 @@
       >{{$curriculum->name}}</option>
       @endforeach
     </select>
+    <script>
+      $("#add_curriculum").on('click', function(e){
+        console.log('hoge');
+        $("#new_curriculums").append('<input type="text" class="form-control mt-1" name="new_curriculums[]" placeholder="{{__('labels.curriculums').__('labels.add')}}">');
+      });
+    </script>

--- a/resources/views/curriculums/components/select_list.blade.php
+++ b/resources/views/curriculums/components/select_list.blade.php
@@ -1,11 +1,13 @@
     <label>{{__('labels.curriculums_name')}}</label>
     <span class="right badge badge-secondary ml-1">{{__('labels.optional')}}</span>
+    {{--新規カリキュラム追加は別画面でやる。要望に備えてコメントアウト
     <a href="javascript:void(0);" id="add_curriculum" class="btn btn-default btn-sm ml-1" title="{{__('labels.curriculums').__('labels.add_button')}}">
       <i class="fa fa-plus"></i>
     </a>
     <a href="javascript:void(0);" id="clear_curriculum" class="btn btn-default btn-sm ml-1" title="{{__('labels.curriculums').__('labels.delete_button')}}">
       <i class="fa fa-trash"></i>
     </a>
+    --}}
     <select name="curriculum_ids[]" class="form-control select2" id="select_curriculum" width=100%  multiple="multiple">
       @foreach($curriculums as $curriculum)
       <option value="{{$curriculum->id}}"
@@ -17,7 +19,7 @@
     </select>
     <script>
       $("#add_curriculum").on('click', function(e){
-        $("#new_curriculums").append('<input type="text" class="form-control mt-1" name="new_curriculums[]" placeholder="{{__('labels.curriculums').__('labels.add')}}" query_check_error="この単元は既に登録済みです。" required="true">');
+        $("#new_curriculums").append('<input type="text" class="form-control mt-1" name="new_curriculums[]" placeholder="{{__('labels.curriculums').__('labels.add')}}"  required="true">');
       });
       $("#clear_curriculum").on('click', function(e){
         console.log('hoge');

--- a/resources/views/curriculums/components/select_list.blade.php
+++ b/resources/views/curriculums/components/select_list.blade.php
@@ -3,6 +3,9 @@
     <a href="javascript:void(0);" id="add_curriculum" class="btn btn-default btn-sm ml-1" title="{{__('labels.curriculums').__('labels.add_button')}}">
       <i class="fa fa-plus"></i>
     </a>
+    <a href="javascript:void(0);" id="clear_curriculum" class="btn btn-default btn-sm ml-1" title="{{__('labels.curriculums').__('labels.delete_button')}}">
+      <i class="fa fa-trash"></i>
+    </a>
     <select name="curriculum_ids[]" class="form-control select2" id="select_curriculum" width=100%  multiple="multiple">
       @foreach($curriculums as $curriculum)
       <option value="{{$curriculum->id}}"
@@ -14,7 +17,10 @@
     </select>
     <script>
       $("#add_curriculum").on('click', function(e){
+        $("#new_curriculums").append('<input type="text" class="form-control mt-1" name="new_curriculums[]" placeholder="{{__('labels.curriculums').__('labels.add')}}" query_check_error="この単元は既に登録済みです。" required="true">');
+      });
+      $("#clear_curriculum").on('click', function(e){
         console.log('hoge');
-        $("#new_curriculums").append('<input type="text" class="form-control mt-1" name="new_curriculums[]" placeholder="{{__('labels.curriculums').__('labels.add')}}">');
+        $('#new_curriculums').empty();
       });
     </script>

--- a/resources/views/curriculums/create.blade.php
+++ b/resources/views/curriculums/create.blade.php
@@ -19,7 +19,7 @@
         <div class="col-12">
           <label>{{__('labels.subject')}}</label>
           <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
-          <select name="subject_ids[]" class="form-control select2" width="100%" multiple="multiple" required="true">
+          <select name="subject_ids[]" class="form-control select2" width="100%" required="true">
             @foreach($subjects as $subject)
             <option value="{{$subject->id}}"
             @if(!empty($item) && $_edit)

--- a/resources/views/curriculums/create.blade.php
+++ b/resources/views/curriculums/create.blade.php
@@ -7,13 +7,6 @@
     <form method="POST" action="/{{$domain}}" id="create_{{$domain}}_form" enctype="multipart/form-data">
     @endif
       @csrf
-      <div class="row mt-2">
-        <div class="col-12">
-          <label>{{__('labels.'.$domain.'_name')}}</label>
-          <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
-          <input type="text" class="form-control" name="name" placeholder="{{__('labels.curriculums_name')}}" required="true" value="{{$_edit ? $item->name : ''}}">
-        </div>
-      </div>
       @if($domain == 'curriculums')
       <div class="row mt-2">
         <div class="col-12">
@@ -32,6 +25,14 @@
         </div>
       </div>
       @endif
+      <div class="row mt-2">
+        <div class="col-12">
+          <label>{{__('labels.'.$domain.'_name')}}</label>
+          <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
+          <input type="text" class="form-control" name="name" placeholder="{{__('labels.curriculums_name')}}" required="true" value="{{$_edit ? $item->name : ''}}">
+        </div>
+      </div>
+
 
       <div class="row mt-2">
         <div class="col-12">

--- a/resources/views/curriculums/create.blade.php
+++ b/resources/views/curriculums/create.blade.php
@@ -20,6 +20,7 @@
           <label>{{__('labels.subject')}}</label>
           <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
           <select name="subject_ids[]" class="form-control select2" width="100%" required="true">
+            <option value="">{{__('labels.selectable')}}</option>
             @foreach($subjects as $subject)
             <option value="{{$subject->id}}"
             @if(!empty($item) && $_edit)

--- a/resources/views/dashboard/widget/tasks.blade.php
+++ b/resources/views/dashboard/widget/tasks.blade.php
@@ -129,11 +129,10 @@
                 <i class="fa fa-clock"></i>
                 {{$item->create_user->details()->name()}}/
                 {{$item->dateweek_format($item->created_at,'Y/m/d')}}  {{date('H:i',strtotime($item->created_at))}}
-                <button type="button" class="btn btn-sm btn-secondary rounded-circle toggle-btn ml-2" data-toggle="collapse" target="setting_details{{$loop->iteration}}"><i class="fas fa-angle-down"></i></button>
+                <a class="toggle-btn ml-2" data-toggle="collapse" target="setting_details{{$loop->iteration}}"><i class="fas fa-chevron-circle-down fa-lg"></i></a>
               </small>
-
             </div>
-            <div class="row mt-5 collapse" id="setting_details{{$loop->iteration}}">
+            <div class="row mt-4 collapse" id="setting_details{{$loop->iteration}}">
               <div class="col-12">
                 @component('tasks.components.buttons',[
                   'item' => $item,
@@ -148,7 +147,7 @@
                     <i class="fa fa-edit"></i>
                   </a>
                 @if($item->status != "cancel")
-                  <a href="javascript:void(0)" title="{{__('labels.delete')}}" page_form="dialog" page_title="{{__('messages.confirm_delete')}}" page_url="/tasks/{{$item->id}}/cancel" class="btn btn-sm btn-{{config('status_style')['cancel']}} mr-1" role="button">
+                  <a href="javascript:void(0)" title="{{__('labels.delete')}}" page_form="dialog" page_title="{{__('messages.confirm_delete')}}" page_url="/tasks/{{$item->id}}/cancel" class="btn btn-sm btn-danger mr-1" role="button">
                     <i class="fa fa-trash"></i>
                   </a>
                 @endif
@@ -178,8 +177,26 @@
           @endisset
           >
       </div>
-
-      <div class="col-12">
+      <div class="col-6">
+        <label>
+          {{__('labels.type')}}
+        </label>
+        <div class="input-group">
+          <div class="form-check">
+            <label class="form-check-label" for="type_class_record">
+              <input class="frm-check-input icheck flat-green" type="radio" name="search_type" id="type_class_record" value="class_record"  {{request()->get('search_type') == 'class_record' ? 'checked': ''}} checked>
+              {{__('labels.class_record')}}
+            </label>
+          </div>
+          <div class="form-check">
+            <label class="form-check-label" for="type_homework">
+              <input class="frm-check-input icheck flat-green" type="radio" name="search_type" id="type_homework" value="homework" {{request()->get('search_type') == 'homework' ? 'checked': ''}}>
+              {{__('labels.homework')}}
+            </label>
+          </div>
+        </div>
+      </div>
+      <div class="col-6">
         <div class="form-group">
           <label for="search_status" class="w-100">
             {{__('labels.status')}}
@@ -235,7 +252,7 @@
           </div>
         </div>
       </div>
-      <input type="hidden" name="search_type" value="{{request()->search_type}}">
+
       @endslot
     @endcomponent
   </div>

--- a/resources/views/dashboard/widget/tasks.blade.php
+++ b/resources/views/dashboard/widget/tasks.blade.php
@@ -26,13 +26,17 @@
         <div class="row">
           <div class="col-12">
             <h3 class="card-title">
-              <i class="fa fa-{{!empty(request()->get('search_type')) && request()->get('search_type') == 'homework' ? 'book-reader': 'list-alt'}} mr-1"></i>{{!empty(request()->get('search_type')) ? __('labels.'.request()->get('search_type')) : __('labels.tasks')}}
+              <i class="fa fa-history mr-1"></i>
+              {{__('labels.learning_record')}}
             </h3>
           </div>
         </div>
         <div class="card-tools">
-          <a href="javascript:void(0)" page_form="dialog" page_title="{{!empty(request()->get('search_type')) ? __('labels.'.request()->get('search_type')).__('labels.add') : __('labels.tasks').__('labels.add')}}" page_url="/tasks/create?student_id={{$item->id}}&task_type={{request()->get('search_type')}}" title="{{__('labels.add_button')}}" role="button" class="btn btn-tool">
+          <a href="javascript:void(0)" page_form="dialog" page_title="{{!empty(request()->get('search_type')) ? __('labels.'.request()->get('search_type')).__('labels.add') : __('labels.learning_record').__('labels.add')}}" page_url="/tasks/create?student_id={{$item->id}}&task_type={{request()->get('search_type')}}" title="{{__('labels.add_button')}}" role="button" class="btn btn-tool">
             <i class="fa fa-pen nav-icon"></i>
+          </a>
+          <a href="javascript:void(0)" page_form="dialog" page_title="{{__('labels.curriculums').__('labels.add')}}" page_url="/curriculums/create" title="{{__('labels.add_button')}}" role="button" class="btn btn-tool">
+            <i class="fa fa-sitemap nav-icon"></i>
           </a>
           @if(!empty(request()->get('search_type')) && request()->get('search_type') != 'class_record')
           <a href="/students/{{$item->id}}/tasks?search_status[]=done&search_type={{request()->get('search_type')}}" class="btn btn-tool" title="{{__('labels.complete').__('labels.tasks')}}">
@@ -56,19 +60,21 @@
           @foreach($tasks as $item)
           <li class="item">
             <div class="row">
-              <div class="col-12 ">
+              <div class="col-md-1 col-2">
+                <small class="badge badge-{{$item->type == "homework" ? 'danger': 'primary'}}">
+                  <i class="fa fa-{{$item->type == 'homework' ? 'book-reader' : 'chalkboard-teacher'}} fa-2x"></i>
+                </small>
+              </div>
+              <div class="col-md-10 col-10">
                 <div class="row">
                   <div class="col-10 text-wrap">
-                    <a href="javascript:void(0)" title="{{__('labels.details')}}" page_form="dialog" page_title="{{$item->title}}" page_url="/tasks/{{$item->id}}/detail_dialog" role="button">
-                      <h4>
-                        <i class="fa fa-{{$item->type == 'homework' ? 'book-reader' : 'list-alt'}}"></i>
+                    <a href="javascript:void(0)" title="{{__('labels.details')}}" page_form="dialog" page_title="{{$item->title}}" page_url="/tasks/{{$item->id}}/detail_dialog" role="button" style="color: {{$item->type == "homework" ? 'red' : 'sky_blue'}};">
                         {{$item->title}}
-                      </h4>
                     </a>
                   </div>
                   <div class="col-2">
-                    @if(request()->get('search_type') != 'class_record')
-                    <small class="badge badge-{{config('status_style')[$item->status]}}  float-right">
+                    @if($item->type != 'class_record')
+                    <small class="badge badge-{{config('status_style')[$item->status]}} float-right">
                       {{config('attribute.task_status')[$item->status]}}
                     </small>
                     @endif
@@ -118,34 +124,39 @@
                 </div>
               </div>
             </div>
-            <div class="row mt-3">
-              <div class="col-12">
-                @component('tasks.components.buttons',[
-                  'item' => $item,
-                  'is_footer' => false,
-                ])
-                @endcomponent
-                <div class="float-right">
-                  <a href="javascript:void(0)" title="{{__('labels.details')}}" page_form="dialog" page_title="{{$item->title}}" page_url="/tasks/{{$item->id}}/detail_dialog" class="btn btn-secondary btn-sm mr-1" role="button">
-                    <i class="fa fa-file-alt"></i>
-                  </a>
-                  <a href="javascript:void(0)" page_title="{{$item->title}}" page_form="dialog" page_url="/tasks/{{$item->id}}/edit" title="{{__('labels.edit')}}" class="btn btn-sm btn-success mr-1" role="button">
-                    <i class="fa fa-edit"></i>
-                  </a>
-                @if($item->status != "cancel")
-                  <a href="javascript:void(0)" title="{{__('labels.delete')}}" page_form="dialog" page_title="{{__('messages.confirm_delete')}}" page_url="/tasks/{{$item->id}}/cancel" class="btn btn-sm btn-{{config('status_style')['cancel']}} mr-1" role="button">
-                    <i class="fa fa-trash"></i>
-                  </a>
-                @endif
-                </div>
-              </div>
-            </div>
             <div class="col-12">
               <small class="text-muted float-right">
                 <i class="fa fa-clock"></i>
                 {{$item->create_user->details()->name()}}/
                 {{$item->dateweek_format($item->created_at,'Y/m/d')}}  {{date('H:i',strtotime($item->created_at))}}
+                <button type="button" class="btn btn-tool toggle-btn" data-toggle="collapse" target="setting_details{{$loop->iteration}}"><i class="fas fa-angle-down"></i></button>
               </small>
+
+            </div>
+
+            <div class="collapse" id="setting_details{{$loop->iteration}}">
+              <div class="row mt-3">
+                <div class="col-12">
+                  @component('tasks.components.buttons',[
+                    'item' => $item,
+                    'is_footer' => false,
+                  ])
+                  @endcomponent
+                  <div class="float-right">
+                    <a href="javascript:void(0)" title="{{__('labels.details')}}" page_form="dialog" page_title="{{$item->title}}" page_url="/tasks/{{$item->id}}/detail_dialog" class="btn btn-secondary btn-sm mr-1" role="button">
+                      <i class="fa fa-file-alt"></i>
+                    </a>
+                    <a href="javascript:void(0)" page_title="{{$item->title}}" page_form="dialog" page_url="/tasks/{{$item->id}}/edit" title="{{__('labels.edit')}}" class="btn btn-sm btn-success mr-1" role="button">
+                      <i class="fa fa-edit"></i>
+                    </a>
+                  @if($item->status != "cancel")
+                    <a href="javascript:void(0)" title="{{__('labels.delete')}}" page_form="dialog" page_title="{{__('messages.confirm_delete')}}" page_url="/tasks/{{$item->id}}/cancel" class="btn btn-sm btn-{{config('status_style')['cancel']}} mr-1" role="button">
+                      <i class="fa fa-trash"></i>
+                    </a>
+                  @endif
+                  </div>
+                </div>
+              </div>
             </div>
           </li>
           @endforeach

--- a/resources/views/dashboard/widget/tasks.blade.php
+++ b/resources/views/dashboard/widget/tasks.blade.php
@@ -58,10 +58,10 @@
             <div class="row">
               <div class="col-12 ">
                 <div class="row">
-
                   <div class="col-10 text-wrap">
                     <a href="javascript:void(0)" title="{{__('labels.details')}}" page_form="dialog" page_title="{{$item->title}}" page_url="/tasks/{{$item->id}}/detail_dialog" role="button">
                       <h4>
+                        <i class="fa fa-{{$item->type == 'homework' ? 'book-reader' : 'list-alt'}}"></i>
                         {{$item->title}}
                       </h4>
                     </a>
@@ -76,7 +76,7 @@
 
                   <div class="col-12 col-md-9">
                     <div class="row">
-                      <div class="col-12 text-truncate">
+                      <div class="col-12">
                         <small class="text-muted">
                           {{$item->body}}
                         </small>
@@ -129,7 +129,7 @@
                   <a href="javascript:void(0)" title="{{__('labels.details')}}" page_form="dialog" page_title="{{$item->title}}" page_url="/tasks/{{$item->id}}/detail_dialog" class="btn btn-secondary btn-sm mr-1" role="button">
                     <i class="fa fa-file-alt"></i>
                   </a>
-                  <a href="javascript:void(0)" page_title="{{$item->title}}" page_form="dialog" page_url="/tasks/{{$item->id}}/edit?task_type={{request()->get('search_type')}}" title="{{__('labels.edit')}}" class="btn btn-sm btn-success mr-1" role="button">
+                  <a href="javascript:void(0)" page_title="{{$item->title}}" page_form="dialog" page_url="/tasks/{{$item->id}}/edit" title="{{__('labels.edit')}}" class="btn btn-sm btn-success mr-1" role="button">
                     <i class="fa fa-edit"></i>
                   </a>
                 @if($item->status != "cancel")

--- a/resources/views/dashboard/widget/tasks.blade.php
+++ b/resources/views/dashboard/widget/tasks.blade.php
@@ -129,35 +129,33 @@
                 <i class="fa fa-clock"></i>
                 {{$item->create_user->details()->name()}}/
                 {{$item->dateweek_format($item->created_at,'Y/m/d')}}  {{date('H:i',strtotime($item->created_at))}}
-                <button type="button" class="btn btn-tool toggle-btn" data-toggle="collapse" target="setting_details{{$loop->iteration}}"><i class="fas fa-angle-down"></i></button>
+                <button type="button" class="btn btn-sm btn-secondary rounded-circle toggle-btn ml-2" data-toggle="collapse" target="setting_details{{$loop->iteration}}"><i class="fas fa-angle-down"></i></button>
               </small>
 
             </div>
-
-            <div class="collapse" id="setting_details{{$loop->iteration}}">
-              <div class="row mt-3">
-                <div class="col-12">
-                  @component('tasks.components.buttons',[
-                    'item' => $item,
-                    'is_footer' => false,
-                  ])
-                  @endcomponent
-                  <div class="float-right">
-                    <a href="javascript:void(0)" title="{{__('labels.details')}}" page_form="dialog" page_title="{{$item->title}}" page_url="/tasks/{{$item->id}}/detail_dialog" class="btn btn-secondary btn-sm mr-1" role="button">
-                      <i class="fa fa-file-alt"></i>
-                    </a>
-                    <a href="javascript:void(0)" page_title="{{$item->title}}" page_form="dialog" page_url="/tasks/{{$item->id}}/edit" title="{{__('labels.edit')}}" class="btn btn-sm btn-success mr-1" role="button">
-                      <i class="fa fa-edit"></i>
-                    </a>
-                  @if($item->status != "cancel")
-                    <a href="javascript:void(0)" title="{{__('labels.delete')}}" page_form="dialog" page_title="{{__('messages.confirm_delete')}}" page_url="/tasks/{{$item->id}}/cancel" class="btn btn-sm btn-{{config('status_style')['cancel']}} mr-1" role="button">
-                      <i class="fa fa-trash"></i>
-                    </a>
-                  @endif
-                  </div>
+            <div class="row mt-5 collapse" id="setting_details{{$loop->iteration}}">
+              <div class="col-12">
+                @component('tasks.components.buttons',[
+                  'item' => $item,
+                  'is_footer' => false,
+                ])
+                @endcomponent
+                <div class="float-right">
+                  <a href="javascript:void(0)" title="{{__('labels.details')}}" page_form="dialog" page_title="{{$item->title}}" page_url="/tasks/{{$item->id}}/detail_dialog" class="btn btn-secondary btn-sm mr-1" role="button">
+                    <i class="fa fa-file-alt"></i>
+                  </a>
+                  <a href="javascript:void(0)" page_title="{{$item->title}}" page_form="dialog" page_url="/tasks/{{$item->id}}/edit" title="{{__('labels.edit')}}" class="btn btn-sm btn-success mr-1" role="button">
+                    <i class="fa fa-edit"></i>
+                  </a>
+                @if($item->status != "cancel")
+                  <a href="javascript:void(0)" title="{{__('labels.delete')}}" page_form="dialog" page_title="{{__('messages.confirm_delete')}}" page_url="/tasks/{{$item->id}}/cancel" class="btn btn-sm btn-{{config('status_style')['cancel']}} mr-1" role="button">
+                    <i class="fa fa-trash"></i>
+                  </a>
+                @endif
                 </div>
               </div>
             </div>
+
           </li>
           @endforeach
         </ul>

--- a/resources/views/dashboard/widget/tasks.blade.php
+++ b/resources/views/dashboard/widget/tasks.blade.php
@@ -65,7 +65,7 @@
                   <i class="fa fa-{{$item->type == 'homework' ? 'book-reader' : 'chalkboard-teacher'}} fa-2x"></i>
                 </small>
               </div>
-              <div class="col-md-10 col-10">
+              <div class="col-md-11 col-10">
                 <div class="row">
                   <div class="col-10 text-wrap">
                     <a href="javascript:void(0)" title="{{__('labels.details')}}" page_form="dialog" page_title="{{$item->title}}" page_url="/tasks/{{$item->id}}/detail_dialog" role="button" style="color: {{$item->type == "homework" ? 'red' : 'sky_blue'}};">

--- a/resources/views/dashboard/widget/tasks.blade.php
+++ b/resources/views/dashboard/widget/tasks.blade.php
@@ -89,7 +89,7 @@
                       </div>
                     </div>
                   </div>
-                  <div class="col">
+                  <div class="col-6">
                     <div class="row">
                     @if( $item->task_reviews->count() > 0)
                       @foreach($item->task_reviews as $review)

--- a/resources/views/students/page.blade.php
+++ b/resources/views/students/page.blade.php
@@ -153,7 +153,7 @@
             <li class="nav-item mr-1">
               <a class="nav-link btn btn-sm btn-default {{$view == 'page.tasks'  ? 'active ': ''}}" href="/{{$domain}}/{{$item->id}}/tasks">
                 <small>
-                  <i class="fas fa-book-reader"></i>
+                  <i class="fas fa-history"></i>
                   {{__('labels.learning_record')}}
                 </small>
               </a>

--- a/resources/views/students/page.blade.php
+++ b/resources/views/students/page.blade.php
@@ -151,18 +151,10 @@
               </a>
             </li>
             <li class="nav-item mr-1">
-              <a class="nav-link btn btn-sm btn-default {{$view == 'page.tasks' && !empty(request()->search_type) && request()->search_type == 'homework' ? 'active ': ''}}" href="/{{$domain}}/{{$item->id}}/tasks?search_type=homework">
+              <a class="nav-link btn btn-sm btn-default {{$view == 'page.tasks'  ? 'active ': ''}}" href="/{{$domain}}/{{$item->id}}/tasks">
                 <small>
                   <i class="fas fa-book-reader"></i>
-                  {{__('labels.homework')}}
-                </small>
-              </a>
-            </li>
-            <li class="nav-item mr-1">
-              <a class="nav-link btn btn-sm btn-default {{$view == 'page.tasks' && !empty(request()->search_type) && request()->search_type == 'class_record' ? 'active ': ''}}" href="/{{$domain}}/{{$item->id}}/tasks?search_type=class_record&search_status[]=done">
-                <small>
-                  <i class="fa fa-list-alt"></i>
-                  {{__('labels.class_record')}}
+                  {{__('labels.learning_record')}}
                 </small>
               </a>
             </li>

--- a/resources/views/tasks/components/curriculums.blade.php
+++ b/resources/views/tasks/components/curriculums.blade.php
@@ -1,0 +1,30 @@
+<div class="row mt-2">
+  <div class="col-12">
+    <label>{{__('labels.curriculums_name')}}</label>
+    <span class="right badge badge-secondary ml-1">{{__('labels.optional')}}</span>
+    <select name="curriculum_ids[]" class="form-control select2"  width=100%  multiple="multiple">
+      @foreach($curriculums as $curriculum)
+      <option value="{{$curriculum->id}}"
+      @if(!empty($item) && $_edit)
+        {{$item->curriculums->contains($curriculum->id)  ? "selected" : "" }}
+      @endif
+      >{{$curriculum->name}}</option>
+      @endforeach
+    </select>
+    <a class="btn btn-primary" role="button" id="add_curriculum">
+      <i class="fa fa-plus"></i>
+    </a>
+    <div id="curriculums">
+
+    </div>
+  </div>
+</div>
+
+<script>
+$("#add_curriculum").on("click", function(e){
+  $("#curriculums").load('{{request()->task_type}}');
+});
+$("#select_subject").on('change', function(e){
+  $('#curriculums').load( "{{url('/curriculums')}}?search_subject_id="+$('select#select_subject').val() );
+});
+</script>

--- a/resources/views/tasks/contents.blade.php
+++ b/resources/views/tasks/contents.blade.php
@@ -62,11 +62,22 @@
                 <a href="/tasks/{{$item->id}}" title="{{__('labels.details')}}">
                   {{$item->title}}
                 </a>
+                <small>
+                  by {{$item->create_user->details()->name()}}
+                </small>
               </div>
               <div class="col-12 text-truncate">
                 <small class="text-muted">
                   {{$item->body}}
                 </small>
+              </div>
+              <div class="col-12 text-truncate">
+                <small class="text-muted">
+                  <a href="{{$item->target_user->details()->domain}}/{{$item->target_user->details()->id}}/tasks">
+                    {{$item->target_user->details()->name()}}
+                  </a>
+                </small>
+
               </div>
             </div>
           </div>

--- a/resources/views/tasks/create.blade.php
+++ b/resources/views/tasks/create.blade.php
@@ -16,22 +16,26 @@
           <input type="text" class="form-control" name="title" placeholder="{{__('labels.title')}}" required="true" value="{{$_edit ? $item->title : ''}}">
         </div>
       </div>
-
       <div class="row mt-2">
-        <div class="col-12">
-          <label>{{__('labels.curriculums_name')}}</label>
+        <div class="col-6">
+          <label>{{__('labels.subjects')}}</label>
           <span class="right badge badge-secondary ml-1">{{__('labels.optional')}}</span>
-          <select name="curriculum_ids[]" class="form-control select2"  width=100%  multiple="multiple">
-            @foreach($curriculums as $curriculum)
-            <option value="{{$curriculum->id}}"
+          <select name="subject_id" id="select_subject" class="form-control select2">
+            @foreach($subjects as $subject)
+            <option value="{{$subject->id}}"
             @if(!empty($item) && $_edit)
-              {{$item->curriculums->contains($curriculum->id)  ? "selected" : "" }}
+              {{$item->curriculums->subjects->contains($basubject->id)  ? "selected" : "" }}
             @endif
-            >{{$curriculum->name}}</option>
+            >
+              {{$subject->name}}</option>
             @endforeach
           </select>
         </div>
+        <div class="col-6" id="curriculums">
+
+        </div>
       </div>
+
 
       <div class="row mt-2">
         <div class="col-12">
@@ -142,3 +146,14 @@
       </div>
     </form>
   </div>
+  <script>
+  $("#add_curriculum").on("click", function(e){
+    $("#curriculums").load('{{request()->task_type}}');
+  });
+  $("#select_subject").on('change', function(e){
+
+    $('#curriculums').load( "{{url('/curriculums/get_select_list')}}?subject_id="+$('select#select_subject').val() );
+    base.pageSettinged('curriculum_select');
+
+  });
+  </script>

--- a/resources/views/tasks/create.blade.php
+++ b/resources/views/tasks/create.blade.php
@@ -13,13 +13,14 @@
           <label>
             {{__('labels.type')}}
           </label>
+          <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
           <div class="input_group">
             <label class="form-check-label" for="type_homework">
-              <input class="frm-check-input icheck flat-green" type="radio" name="type" id="type_homework" value="homework" required="true">
+              <input class="frm-check-input icheck flat-green" type="radio" name="type" id="type_homework" value="homework" required="true" {{$_edit && $item->type == 'homework' ? 'checked': ''}}>
               {{__('labels.homework')}}
             </label>
             <label class="form-check-label" for="type_class_record">
-              <input class="frm-check-input icheck flat-green" type="radio" name="type" id="type_class_record" value="class_record" required="true">
+              <input class="frm-check-input icheck flat-green" type="radio" name="type" id="type_class_record" value="class_record" required="true" {{$_edit && $item->type == 'class_record' ? 'checked': ''}}>
               {{__('labels.class_record')}}
             </label>
           </div>
@@ -35,7 +36,7 @@
             @foreach($subjects as $subject)
             <option value="{{$subject->id}}"
             @if(!empty($item) && $_edit)
-              {{$item->curriculums->first()->subjects->contains($subject->id)  ? "selected" : "" }}
+              {{$item->curriculums->count() >0 && $item->curriculums->first()->subjects->contains($subject->id)  ? "selected" : "" }}
             @endif
             >
             {{$subject->name}}</option>
@@ -53,11 +54,14 @@
         <div class="col-12">
           <label>{{__('labels.title')}}</label>
           <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
-          <a href="javascript:void(0)" class="btn btn-default btn-sm" id="title_set">
-            <i class="fa fa-plus"></i>
-            自動セット
-          </a>
-          <input type="text" class="form-control" name="title" id="title" placeholder="{{__('labels.title')}}" required="true" value="{{$_edit ? $item->title : ''}}">
+          <div class="input-group mb-3">
+            <input type="text" class="form-control" name="title" id="title" placeholder="{{__('labels.title')}}" required="true" value="{{$_edit ? $item->title : ''}}">
+            <div class="input-group-append">
+              <button class="btn btn-info" type="button" id="title_set">
+                <i class="fa fa-copy"></i>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
       <div class="row mt-2">
@@ -170,8 +174,31 @@
     </form>
   </div>
   <script>
+
+  $(function(){
+    var grade = "{{$target_student->tag_value('grade')}}";
+    var school = grade.match(/^./)[0];
+    console.log(school);
+    $('select#select_subject option').each(function(){
+      if($(this).text().match("選択") != null ){
+      }else if(school == "e" && $(this).text().match("小学") == null){
+        $(this).remove();
+      }else if(school == "j" && $(this).text().match("中学") == null){
+        $(this).remove();
+      }else if(school == "h" &&  ($(this).text().match("中学") != null   || $(this).text().match("小学") != null)){
+        $(this).remove();
+      }
+    });
+    @if($_edit && $item->curriculums->count() > 0)
+    $('#curriculums').load( "{{url('/curriculums/get_select_list')}}?subject_id="+$('select#select_subject').val()
+    +"&task_id={{$item->id}}", function(){
+      base.pageSettinged('create_tasks');
+    });
+    @endif
+  });
+
   $("#select_subject").on('change', function(e){
-    $('#curriculums').load( "{{url('/curriculums/get_select_list')}}?subject_id="+$('select#select_subject').val(), function(){
+    $('#curriculums').load( "{{url('/curriculums/get_select_list')}}?subject_id="+$('select#select_subject').val(),function(){
       base.pageSettinged('create_tasks');
     });
   });
@@ -187,5 +214,6 @@
     console.log("hoge");
     $("#title").val(title);
   });
+
 
   </script>

--- a/resources/views/tasks/create.blade.php
+++ b/resources/views/tasks/create.blade.php
@@ -8,35 +8,62 @@
     @endif
       @csrf
       <input type="hidden" name="target_user_id" value="{{$target_student->user_id}}">
-      <input type="hidden" name="type" value="{{$task_type}}">
-      <div class="row mt-2">
+      <div class="row">
         <div class="col-12">
-          <label>{{__('labels.title')}}</label>
-          <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
-          <input type="text" class="form-control" name="title" placeholder="{{__('labels.title')}}" required="true" value="{{$_edit ? $item->title : ''}}">
+          <label>
+            {{__('labels.type')}}
+          </label>
+          <div class="input_group">
+            <label class="form-check-label" for="type_homework">
+              <input class="frm-check-input icheck flat-green" type="radio" name="type" id="type_homework" value="homework" required="true">
+              {{__('labels.homework')}}
+            </label>
+            <label class="form-check-label" for="type_class_record">
+              <input class="frm-check-input icheck flat-green" type="radio" name="type" id="type_class_record" value="class_record" required="true">
+              {{__('labels.class_record')}}
+            </label>
+          </div>
         </div>
       </div>
+
       <div class="row mt-2">
         <div class="col-6">
           <label>{{__('labels.subjects')}}</label>
           <span class="right badge badge-secondary ml-1">{{__('labels.optional')}}</span>
-          <select name="subject_id" id="select_subject" class="form-control select2">
+          <select name="subject_id" id="select_subject" width="100%" class="form-control select2">
+            <option value=" ">{{__('labels.selectable')}}</option>
             @foreach($subjects as $subject)
             <option value="{{$subject->id}}"
             @if(!empty($item) && $_edit)
               {{$item->curriculums->subjects->contains($basubject->id)  ? "selected" : "" }}
             @endif
             >
-              {{$subject->name}}</option>
+            {{$subject->name}}</option>
             @endforeach
           </select>
         </div>
-        <div class="col-6" id="curriculums">
+        <div class="col-6">
+          <div class="row">
+            <div class="col-12" id="curriculums">
 
+            </div>
+            <div class="col-12" id="new_curriculums">
+
+            </div>
+          </div>
         </div>
       </div>
-
-
+      <div class="row mt-2">
+        <div class="col-12">
+          <label>{{__('labels.title')}}</label>
+          <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
+          <a href="javascript:void(0)" class="btn btn-default btn-sm" id="title_set">
+            <i class="fa fa-plus"></i>
+            自動セット
+          </a>
+          <input type="text" class="form-control" name="title" id="title" placeholder="{{__('labels.title')}}" required="true" value="{{$_edit ? $item->title : ''}}">
+        </div>
+      </div>
       <div class="row mt-2">
         <div class="col-12">
           <h3 class="card-title">
@@ -147,13 +174,22 @@
     </form>
   </div>
   <script>
-  $("#add_curriculum").on("click", function(e){
-    $("#curriculums").load('{{request()->task_type}}');
-  });
   $("#select_subject").on('change', function(e){
-
-    $('#curriculums').load( "{{url('/curriculums/get_select_list')}}?subject_id="+$('select#select_subject').val() );
-    base.pageSettinged('curriculum_select');
-
+    $('#curriculums').load( "{{url('/curriculums/get_select_list')}}?subject_id="+$('select#select_subject').val(), function(){
+      base.pageSettinged('create_tasks');
+    });
   });
+  $("#title_set").on('click', function(e){
+    var curriculums = "";
+    $("#select_curriculum option:selected").each(function(){
+      curriculums += $(this).text() +"_";
+    });
+    $('input:text[name="new_curriculums[]"]').each(function(){
+      curriculums += $(this).val() + "_";
+    });
+    var title = $("#select_subject option:selected" ).text().trim() + '_' +  curriculums + $('input:radio[name="type"]:checked').parent().parent().text().trim();
+    console.log("hoge");
+    $("#title").val(title);
+  });
+
   </script>

--- a/resources/views/tasks/create.blade.php
+++ b/resources/views/tasks/create.blade.php
@@ -209,13 +209,12 @@
   $("#title_set").on('click', function(e){
     var curriculums = "";
     $("#select_curriculum option:selected").each(function(){
-      curriculums += $(this).text() +"_";
+      curriculums += "_" + $(this).text();
     });
     $('input:text[name="new_curriculums[]"]').each(function(){
-      curriculums += $(this).val() + "_";
+      curriculums += "_" + $(this).val();
     });
-    var title = $("#select_subject option:selected" ).text().trim() + '_' +  curriculums + $('input:radio[name="type"]:checked').parent().parent().text().trim();
-    console.log("hoge");
+    var title = $("#select_subject option:selected" ).text().trim() +  curriculums;
     $("#title").val(title);
   });
 

--- a/resources/views/tasks/create.blade.php
+++ b/resources/views/tasks/create.blade.php
@@ -27,7 +27,7 @@
       </div>
 
       <div class="row mt-2">
-        <div class="col-6">
+        <div class="col-12 mb-2">
           <label>{{__('labels.subjects')}}</label>
           <span class="right badge badge-secondary ml-1">{{__('labels.optional')}}</span>
           <select name="subject_id" id="select_subject" width="100%" class="form-control select2">
@@ -35,22 +35,18 @@
             @foreach($subjects as $subject)
             <option value="{{$subject->id}}"
             @if(!empty($item) && $_edit)
-              {{$item->curriculums->subjects->contains($basubject->id)  ? "selected" : "" }}
+              {{$item->curriculums->first()->subjects->contains($subject->id)  ? "selected" : "" }}
             @endif
             >
             {{$subject->name}}</option>
             @endforeach
           </select>
         </div>
-        <div class="col-6">
-          <div class="row">
-            <div class="col-12" id="curriculums">
+        <div class="col-12" id="curriculums">
 
-            </div>
-            <div class="col-12" id="new_curriculums">
+        </div>
+        <div class="col-12" id="new_curriculums">
 
-            </div>
-          </div>
         </div>
       </div>
       <div class="row mt-2">

--- a/resources/views/tasks/create.blade.php
+++ b/resources/views/tasks/create.blade.php
@@ -14,15 +14,19 @@
             {{__('labels.type')}}
           </label>
           <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
-          <div class="input_group">
-            <label class="form-check-label" for="type_homework">
-              <input class="frm-check-input icheck flat-green" type="radio" name="type" id="type_homework" value="homework" required="true" {{$_edit && $item->type == 'homework' ? 'checked': ''}}>
-              {{__('labels.homework')}}
-            </label>
-            <label class="form-check-label" for="type_class_record">
-              <input class="frm-check-input icheck flat-green" type="radio" name="type" id="type_class_record" value="class_record" required="true" {{$_edit && $item->type == 'class_record' ? 'checked': ''}}>
-              {{__('labels.class_record')}}
-            </label>
+          <div class="input-group">
+            <div class="form-check">
+              <label class="form-check-label" for="type_class_record">
+                <input class="frm-check-input icheck flat-green" type="radio" name="type" id="type_class_record" value="class_record" required="true" {{$_edit && $item->type == 'class_record' ? 'checked': ''}} checked>
+                {{__('labels.class_record')}}
+              </label>
+            </div>
+            <div class="form-check">
+              <label class="form-check-label" for="type_homework">
+                <input class="frm-check-input icheck flat-green" type="radio" name="type" id="type_homework" value="homework" required="true" {{$_edit && $item->type == 'homework' ? 'checked': ''}}>
+                {{__('labels.homework')}}
+              </label>
+            </div>
           </div>
         </div>
       </div>
@@ -151,14 +155,14 @@
           </label>
           <div class="input-group">
             <div class="form-check">
-              <input class="frm-check-input icheck flat-green" type="radio" name="mail_send" id="mail_send_yes" value="yes" required="true">
               <label class="form-check-label" for="mail_send_yes">
+              <input class="frm-check-input icheck flat-green" type="radio" name="mail_send" id="mail_send_yes" value="yes" required="true">
                 {{__('labels.task_remind')}}
               </label>
             </div>
             <div class="form-check">
-              <input class="frm-check-input icheck flat-green" type="radio" name="mail_send" id="mail_send_no" value="no" required="true" checked>
               <label class="form-check-label" for="mail_send_no">
+              <input class="frm-check-input icheck flat-green" type="radio" name="mail_send" id="mail_send_no" value="no" required="true" checked>
                 {{__('labels.no_remind')}}
               </label>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -361,7 +361,9 @@ Route::get('tasks/{id}/review', 'TaskController@show_review_page');
 Route::put('tasks/{id}/review', 'TaskController@review');
 Route::post('task_comments/create', 'TaskCommentController@store');
 
+Route::get('curriculums/get_select_list','CurriculumController@get_select_list');
 Route::resource('curriculums','CurriculumController');
 Route::get('curriculums/{id}/delete', 'CurriculumController@delete');
+
 Route::resource('subjects','SubjectController');
 Route::get('subjects/{id}/delete', 'SubjectController@delete');

--- a/routes/web.php
+++ b/routes/web.php
@@ -362,6 +362,7 @@ Route::put('tasks/{id}/review', 'TaskController@review');
 Route::post('task_comments/create', 'TaskCommentController@store');
 
 Route::get('curriculums/get_select_list','CurriculumController@get_select_list');
+Route::get('curriculums/name/{name}', 'CurriculumController@name_check');
 Route::resource('curriculums','CurriculumController');
 Route::get('curriculums/{id}/delete', 'CurriculumController@delete');
 


### PR DESCRIPTION
タスクの機能改修
・宿題と授業記録を統合
・追加フォームの変更
　-レイアウト変更
　-科目を学年で絞込
　-単元を科目で絞込
　-概要の自動入力
　-宿題と授業記録を選ぶように変更

・リストのデザイン変更
　-宿題→red
　-授業記録→blue
　-詳細をtruncateしない
　-ボタンを折り畳み
　-タスク追加ボタンの横に単元追加ボタン配置


確認事項
・タスクが登録できること
　-登録フォームで学年に合わせた科目と単元が出てくること
　-大人、大学生、幼児はすべて表示される
・単元が登録できること
・単元が登録できること