### PR TITLE
サイドメニューの予定追加のみ残す

### DIFF
--- a/resources/views/components/menu/navbar/user_nav.blade.php
+++ b/resources/views/components/menu/navbar/user_nav.blade.php
@@ -46,7 +46,6 @@
       <a href="/teachers/{{$user->id}}/schedule?list=confirm" class="dropdown-item">{{__('labels.adjust_schedule_list')}}</a>
       <a href="/teachers/{{$user->id}}/schedule?list=cancel" class="dropdown-item">{{__('labels.rest_schedule_list')}}</a>
       <a href="/teachers/{{$user->id}}/schedule?list=history" class="dropdown-item">{{__('labels.schedule_history')}}</a>
-      <a class="dropdown-item" href="javascript:void(0);" page_form="dialog" page_url="/calendars/create?teacher_id={{$user->id}}" page_title="{{__('labels.schedule_add')}}">{{__('labels.schedule_add')}}</a>
     </div>
   </li>
 @elseif($user->role==="manager")

--- a/resources/views/teachers/calendar.blade.php
+++ b/resources/views/teachers/calendar.blade.php
@@ -13,10 +13,12 @@
         @component('components.calendar', ['user' => $user, 'teacher_id' => $item->id, 'domain' => $domain, 'filter'=>$filter, 'item'=>$item, 'attributes' => $attributes])
           @slot('event_select')
           // 選択可
+          @if($user->role=='manager')
           selectable: true,
           select: function(start, end, jsEvent, view , resource){
             event_create(start, end, jsEvent, view , resource);
           },
+          @endif
           @endslot
           @slot('event_click')
           eventClick: function(event, jsEvent, view) {

--- a/resources/views/teachers/schedule.blade.php
+++ b/resources/views/teachers/schedule.blade.php
@@ -7,14 +7,6 @@
 @section('schedule_list_pager')
 @component('components.list_pager', ['_page' => $_page, '_maxpage' => $_maxpage, '_list_start' => $_list_start, '_list_end'=>$_list_end, '_list_count'=>$_list_count])
   @slot("addon_button")
-  <ul class="pagination pagination-sm m-0 float-left text-sm">
-    <li class="page-item ml-1">
-      <a class="btn btn-info btn-sm" href="javascript:void(0);"  page_form="dialog" page_url="/calendars/create?teacher_id={{$item->id}}" page_title="{{__('labels.schedule_add')}}">
-        <i class="fa fa-plus"></i>
-        <span class="btn-label">{{__('labels.add')}}</span>
-      </a>
-    </li>
-  </ul>
   @endslot
 @endcomponent
 @endsection


### PR DESCRIPTION
カレンダークリックの登録は、事務のみ可能にしておく