### PR TITLE
郵便番号によって住所を自動入力する

### DIFF
--- a/public/js/base/base.js
+++ b/public/js/base/base.js
@@ -120,9 +120,10 @@
 		$('input[type="checkbox"].icheck, input[type="radio"].icheck').on('ifChanged', function (e) {
 			$(this).trigger("change", e);
 		});
-		/*
 		//郵便番号入力
 		dom.setPostnoForm(form_id);
+
+		/*
 		//数値入力
 		dom.setNumberForm(form_id);
 		*/

--- a/resources/views/layouts/start.blade.php
+++ b/resources/views/layouts/start.blade.php
@@ -89,6 +89,8 @@
 <script src="{{asset('js/plugins/ckeditor/ckeditor.js')}}"></script>
 <!-- Bootstrap WYSIHTML5 -->
 <script src="{{asset('js/plugins/bootstrap-wysihtml5/bootstrap3-wysihtml5.all.min.js')}}"></script>
+<!-- jpostal-->
+<script type="text/javascript" src="https://jpostal-1006.appspot.com/jquery.jpostal.js"></script>
 
 <!-- AdminLTE App -->
 <script src="{{asset('dist/js/adminlte.js')}}"></script>

--- a/resources/views/students/forms/address.blade.php
+++ b/resources/views/students/forms/address.blade.php
@@ -10,7 +10,7 @@
     @if(isset($is_label) && $is_label===true)
     <span>{{$item['post_no']}}</span>
     @else
-    <input type="text" name="post_no" class="form-control" placeholder="例：1112222" inputtype="number" maxlength=7 required="true"
+    <input type="text" name="post_no" class="form-control" placeholder="例：1112222" inputtype="number" maxlength=7 uitype="jpostal"  required="true"
     value="@if(isset($item) && isset($item['post_no'])){{$item['post_no']}}@endif"
     >
     @endif
@@ -27,7 +27,7 @@
     @if(isset($is_label) && $is_label===true)
     <span>{{$item['address']}}</span>
     @else
-    <input type="text" name="address" class="form-control" placeholder="例：東京都八王子市〇〇１－２－３" inputtype="zenkaku" required="true"
+    <input type="text" name="address" class="form-control" placeholder="例：東京都八王子市〇〇１－２－３" inputtype="zenkaku" required="true" accesskey="post_no" alt="%3 %4 %5"
     value="@if(isset($item) && isset($item['address'])){{$item['address']}}@endif"
     >
     @endif


### PR DESCRIPTION
 base.js
  dom.setPostnoFormを有効化
　start.blade.php
  jpostalをinclude CDN版
　address.blade.php
  jpostal用にuitype altを追加


managers, teachers等の登録画面で郵便番号を入力すると住所が番地の前まで自動で入力される

・lmsから新規登録
・受信したメールから登録画面を開く
・郵便番号の入力で住所が自動入力されることを確認