### PR TITLE
Feature/500

### DIFF
--- a/public/js/base/base.js
+++ b/public/js/base/base.js
@@ -484,6 +484,7 @@
 					if(!confirm(_confirm)) return false;
 				}
 				util.clearLocalData();
+				$(this).prop("disabled", true);
         $("#"+form).submit();
       });
       //サブページ内のreset

--- a/resources/views/asks/agreement.blade.php
+++ b/resources/views/asks/agreement.blade.php
@@ -58,6 +58,7 @@
             $("#commit_form button.btn-submit").on('click', function(e){
               e.preventDefault();
               if(front.validateFormValue('commit_form')){
+                $(this).prop("disabled",true);
                 $("#commit_form form").submit();
               }
             });
@@ -78,6 +79,7 @@ $(function(){
       if(!confirm(_confirm)) return false;
     }
     if(front.validateFormValue('admission_mail')){
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/asks/ask_create.blade.php
+++ b/resources/views/asks/ask_create.blade.php
@@ -117,6 +117,7 @@ $(function(){
   $("button.btn-submit").on('click', function(e){
     e.preventDefault();
     if(front.validateFormValue('ask_entry .carousel-item.active')){
+      $(this).prop("disabled",true);
       $("#edit").submit();
     }
   });

--- a/resources/views/asks/cancel.blade.php
+++ b/resources/views/asks/cancel.blade.php
@@ -27,6 +27,7 @@
       $("#cancel_form button.btn-submit").on('click', function(e){
         e.preventDefault();
         if(front.validateFormValue('cancel_form')){
+          $(this).prop("disabled",true);
           $("#cancel_form form").submit();
         }
       });

--- a/resources/views/asks/commit.blade.php
+++ b/resources/views/asks/commit.blade.php
@@ -27,6 +27,7 @@
       $("#commit_form button.btn-submit").on('click', function(e){
         e.preventDefault();
         if(front.validateFormValue('commit_form')){
+          $(this).prop("disabled",true);
           $("#commit_form form").submit();
         }
       });

--- a/resources/views/asks/forms/recess_form.blade.php
+++ b/resources/views/asks/forms/recess_form.blade.php
@@ -85,6 +85,7 @@ $(function(){
       if(!util.isEmpty(_confirm)){
         if(!confirm(_confirm)) return false;
       }
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/asks/forms/unsubscribe_form.blade.php
+++ b/resources/views/asks/forms/unsubscribe_form.blade.php
@@ -85,6 +85,7 @@ $(function(){
       if(!util.isEmpty(_confirm)){
         if(!confirm(_confirm)) return false;
       }
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/asks/remind.blade.php
+++ b/resources/views/asks/remind.blade.php
@@ -27,6 +27,7 @@
       $("#commit_form button.btn-submit").on('click', function(e){
         e.preventDefault();
         if(front.validateFormValue('commit_form')){
+          $(this).prop("disabled",true);
           $("#commit_form form").submit();
         }
       });

--- a/resources/views/asks/simplepage.blade.php
+++ b/resources/views/asks/simplepage.blade.php
@@ -49,6 +49,7 @@
       $("button.btn-submit").on('click', function(e){
         e.preventDefault();
         if(front.validateFormValue('commit_form')){
+          $(this).prop("disabled",true);
           $("#commit_form form").submit();
         }
       });

--- a/resources/views/auth/email_edit.blade.php
+++ b/resources/views/auth/email_edit.blade.php
@@ -90,6 +90,7 @@ $(function(){
   $("button.btn-submit").on('click', function(e){
     e.preventDefault();
     if(front.validateFormValue('email_edit .carousel-item.active')){
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/auth/forget.blade.php
+++ b/resources/views/auth/forget.blade.php
@@ -49,6 +49,7 @@ $(function(){
     console.log("login");
     e.preventDefault();
     if(front.validateFormValue('forget_form')){
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/auth/login/login_form.blade.php
+++ b/resources/views/auth/login/login_form.blade.php
@@ -47,6 +47,7 @@ $(function(){
     save_login_info();
     e.preventDefault();
     if(front.validateFormValue('login_form')){
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/auth/reset.blade.php
+++ b/resources/views/auth/reset.blade.php
@@ -43,6 +43,7 @@ $(function(){
     console.log("reset_form");
     e.preventDefault();
     if(front.validateFormValue('reset_form')){
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/calendar_settings/all_to_calendar.blade.php
+++ b/resources/views/calendar_settings/all_to_calendar.blade.php
@@ -32,6 +32,7 @@ $(function(){
   $("button.btn-submit").on('click', function(e){
     e.preventDefault();
     if(front.validateFormValue('calendar_settings_to_calendar')){
+      $(this).prop("disabled",true);
       $('form').submit();
     }
   });

--- a/resources/views/calendar_settings/create.blade.php
+++ b/resources/views/calendar_settings/create.blade.php
@@ -113,6 +113,7 @@ $(function(){
   $("button.btn-submit").on('click', function(e){
     e.preventDefault();
     if(front.validateFormValue('calendar_settings_entry .carousel-item.active')){
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/calendar_settings/delete_calendar.blade.php
+++ b/resources/views/calendar_settings/delete_calendar.blade.php
@@ -31,6 +31,7 @@ $(function(){
   $("button.btn-submit").on('click', function(e){
     e.preventDefault();
     if(front.validateFormValue('calendar_settings_delete_calendar') && select_ids_check_validate()){
+      $(this).prop("disabled",true);
       $('form').submit();
     }
   });

--- a/resources/views/calendar_settings/fix.blade.php
+++ b/resources/views/calendar_settings/fix.blade.php
@@ -40,6 +40,7 @@
       $("button.btn-submit").on('click', function(e){
         e.preventDefault();
         if(front.validateFormValue('_form')){
+          $(this).prop("disabled",true);
           $("form").submit();
         }
       });

--- a/resources/views/calendar_settings/to_calendar.blade.php
+++ b/resources/views/calendar_settings/to_calendar.blade.php
@@ -31,6 +31,7 @@ $(function(){
   $("button.btn-submit").on('click', function(e){
     e.preventDefault();
     if(front.validateFormValue('calendar_settings_to_calendar') && select_dates_check_validate()){
+      $(this).prop("disabled",true);
       $('form').submit();
     }
   });

--- a/resources/views/calendars/create.blade.php
+++ b/resources/views/calendars/create.blade.php
@@ -96,6 +96,7 @@ $(function(){
   $("button.btn-submit").on('click', function(e){
     e.preventDefault();
     if(front.validateFormValue('calendars_entry .carousel-item.active')){
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/calendars/fix.blade.php
+++ b/resources/views/calendars/fix.blade.php
@@ -41,6 +41,7 @@
       $("button.btn-submit").on('click', function(e){
         e.preventDefault();
         if(front.validateFormValue('_form')){
+          $(this).prop("disabled",true);
           $("form").submit();
         }
       });

--- a/resources/views/calendars/simplepage.blade.php
+++ b/resources/views/calendars/simplepage.blade.php
@@ -96,6 +96,7 @@
     $("button.btn-submit").on('click', function(e){
       e.preventDefault();
       if(front.validateFormValue('_form')){
+        $(this).prop("disabled",true);
         $("form").submit();
       }
     });

--- a/resources/views/components/calendar.blade.php
+++ b/resources/views/components/calendar.blade.php
@@ -29,6 +29,7 @@
       $("input[name=_page]").val(page);
       //subDialog側にformが残っているとsubmitされる対策
       $("#subDialog .modal-dialog").remove();
+      $(this).prop("disabled",true);
       $("#filter_form form.filter").submit();
     });
     $("button[accesskey='filter_search'][type=button]").on('click', function(e){

--- a/resources/views/components/list_filter.blade.php
+++ b/resources/views/components/list_filter.blade.php
@@ -43,12 +43,14 @@ $(function(){
     $("input[name=_page]").val(page);
     //subDialog側にformが残っているとsubmitされる対策
     $("#subDialog .modal-dialog").remove();
+    $(this).prop("disabled",true);
     $("#filter_form form.filter").submit();
   });
   $("button[accesskey='filter_search'][type=button]").on('click', function(e){
     $("input[name=_page]").val("1");
     //subDialog側にformが残っているとsubmitされる対策
     $("#subDialog .modal-dialog").remove();
+    $(this).prop("disabled",true);
     $("#filter_form form.filter").submit();
   });
   $("button[accesskey='filter_search'][type=reset]").on('click', function(e){

--- a/resources/views/components/list_filter_message.blade.php
+++ b/resources/views/components/list_filter_message.blade.php
@@ -37,12 +37,14 @@ $(function(){
     $("input[name=_page]").val(page);
     //subDialog側にformが残っているとsubmitされる対策
     $("#subDialog .modal-dialog").remove();
+    $(this).prop("disabled",true);
     $("#filter_form form.filter").submit();
   });
   $("button[accesskey='filter_search'][type=button]").on('click', function(e){
     $("input[name=_page]").val("1");
     //subDialog側にformが残っているとsubmitされる対策
     $("#subDialog .modal-dialog").remove();
+    $(this).prop("disabled",true);
     $("#filter_form form.filter").submit();
   });
   $("button[accesskey='filter_search'][type=reset]").on('click', function(e){

--- a/resources/views/examinations/question.blade.php
+++ b/resources/views/examinations/question.blade.php
@@ -73,6 +73,7 @@ $(function(){
   $("button.btn-submit").on('click', function(e){
     e.preventDefault();
     if(front.validateFormValue('examination')){
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/faqs/create.blade.php
+++ b/resources/views/faqs/create.blade.php
@@ -160,6 +160,7 @@ $(function(){
   $("button.btn-submit").on('click', function(e){
     e.preventDefault();
     if(front.validateFormValue('{{$domain}}_create')){
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/layouts/carousel.blade.php
+++ b/resources/views/layouts/carousel.blade.php
@@ -78,6 +78,7 @@ $(function(){
   $("button.btn-submit").on('click', function(e){
     e.preventDefault();
     if(front.validateFormValue('carousel_form .carousel-item.active')){
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/managers/edit.blade.php
+++ b/resources/views/managers/edit.blade.php
@@ -61,6 +61,7 @@ $(function(){
   $("button.btn-submit").on('click', function(e){
     e.preventDefault();
     if(front.validateFormValue('managers_edit .carousel-item.active')){
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/managers/entry_form.blade.php
+++ b/resources/views/managers/entry_form.blade.php
@@ -36,6 +36,7 @@ $(function(){
   $("button.btn-submit").on('click', function(e){
     e.preventDefault();
     if(front.validateFormValue('teachers_entry')){
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/managers/register.blade.php
+++ b/resources/views/managers/register.blade.php
@@ -128,6 +128,7 @@ $(function(){
   $("#managers_register button.btn-submit").on('click', function(e){
     e.preventDefault();
     if(front.validateFormValue('managers_register .carousel-item.active')){
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/managers/tag.blade.php
+++ b/resources/views/managers/tag.blade.php
@@ -33,6 +33,7 @@ $(function(){
   $("button.btn-submit").on('click', function(e){
     e.preventDefault();
     if(front.validateFormValue('tag_edit')){
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/parents/edit.blade.php
+++ b/resources/views/parents/edit.blade.php
@@ -41,6 +41,7 @@ $(function(){
   $("button.btn-submit").on('click', function(e){
     e.preventDefault();
     if(front.validateFormValue('parents_edit .carousel-item.active')){
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/parents/entry.blade.php
+++ b/resources/views/parents/entry.blade.php
@@ -68,6 +68,7 @@ $(function(){
   $("button.btn-submit").on('click', function(e){
     e.preventDefault();
     if(front.validateFormValue('_form')){
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/parents/register.blade.php
+++ b/resources/views/parents/register.blade.php
@@ -94,6 +94,7 @@ $(function(){
     e.preventDefault();
     if(front.validateFormValue('parents_register .carousel-item.active')){
       util.removeLocalData('parents_register');
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/students/create_login_info.blade.php
+++ b/resources/views/students/create_login_info.blade.php
@@ -57,12 +57,14 @@
     $('button.btn-submit[form="create_login_info"]').on('click', function(e){
       e.preventDefault();
       if(front.validateFormValue('create_login_info')){
+        $(this).prop("disabled",true);
         $("form#create_login_info").submit();
       }
     });
     $('button.btn-submit[form="reset_login_info"]').on('click', function(e){
       e.preventDefault();
       if(front.validateFormValue('reset_login_info')){
+        $(this).prop("disabled",true);
         $("form#reset_login_info").submit();
       }
     });

--- a/resources/views/students/register.blade.php
+++ b/resources/views/students/register.blade.php
@@ -88,6 +88,7 @@ $(function(){
     e.preventDefault();
     util.removeLocalData('students_add_form');
     if(front.validateFormValue('students_add_form .carousel-item.active')){
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/students/setting.blade.php
+++ b/resources/views/students/setting.blade.php
@@ -62,6 +62,7 @@ $(function(){
   $("button.btn-submit").on('click', function(e){
     e.preventDefault();
     if(front.validateFormValue('students_edit .carousel-item.active')){
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/students/tag.blade.php
+++ b/resources/views/students/tag.blade.php
@@ -33,6 +33,7 @@ $(function(){
   $("button.btn-submit").on('click', function(e){
     e.preventDefault();
     if(front.validateFormValue('tag_edit')){
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/teachers/add_charge_student.blade.php
+++ b/resources/views/teachers/add_charge_student.blade.php
@@ -52,6 +52,7 @@ $(function(){
   $("button.btn-submit").on('click', function(e){
     e.preventDefault();
     if(front.validateFormValue('add_charge_student .carousel-item.active')){
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/teachers/edit.blade.php
+++ b/resources/views/teachers/edit.blade.php
@@ -84,6 +84,7 @@ $(function(){
   $("button.btn-submit").on('click', function(e){
     e.preventDefault();
     if(front.validateFormValue('teachers_edit .carousel-item.active')){
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/teachers/entry_form.blade.php
+++ b/resources/views/teachers/entry_form.blade.php
@@ -36,6 +36,7 @@ $(function(){
   $("button.btn-submit").on('click', function(e){
     e.preventDefault();
     if(front.validateFormValue('{{$domain}}_entry')){
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/teachers/month_work.blade.php
+++ b/resources/views/teachers/month_work.blade.php
@@ -236,6 +236,7 @@
         console.log('submit');
         e.preventDefault();
         if(front.validateFormValue('month_work_confirm')){
+          $(this).prop("disabled",true);
           $("#month_work_post").submit();
         }
       });

--- a/resources/views/teachers/register.blade.php
+++ b/resources/views/teachers/register.blade.php
@@ -143,6 +143,7 @@ $(function(){
   $("button.btn-submit").on('click', function(e){
     e.preventDefault();
     if(front.validateFormValue('teachers_register .carousel-item.active')){
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/teachers/tag.blade.php
+++ b/resources/views/teachers/tag.blade.php
@@ -32,6 +32,7 @@ $(function(){
   $("button.btn-submit").on('click', function(e){
     e.preventDefault();
     if(front.validateFormValue('tag_edit')){
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/trials/confirm.blade.php
+++ b/resources/views/trials/confirm.blade.php
@@ -85,6 +85,7 @@ $(function(){
     e.preventDefault();
     if(front.validateFormValue('trials_confirm .carousel-item.active')){
       util.removeLocalData('trials_confirm');
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/trials/forms/entry_page_script.blade.php
+++ b/resources/views/trials/forms/entry_page_script.blade.php
@@ -20,6 +20,7 @@ $(function(){
   $("button.btn-submit").on('click', function(e){
     e.preventDefault();
     if(front.validateFormValue('trials_entry .carousel-item.active')){
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });

--- a/resources/views/trials/to_calendar.blade.php
+++ b/resources/views/trials/to_calendar.blade.php
@@ -87,6 +87,7 @@ $(function(){
     teacher_schedule_change();
     e.preventDefault();
     if(front.validateFormValue('trial_to_calendar')){
+      $(this).prop("disabled",true);
       $("#trial_to_calendar form").submit();
     }
   });

--- a/resources/views/trials/to_calendar_setting.blade.php
+++ b/resources/views/trials/to_calendar_setting.blade.php
@@ -121,6 +121,7 @@ $(function(){
           return;
         }
       }
+      $(this).prop("disabled",true);
       $("form").submit();
     }
   });


### PR DESCRIPTION
POSTで登録するときにボタンを連打されるとrequestが複数回飛んでしまう

一度押したら無効化することで、ボタン連打を防止する。

modalはbase.jsのshowpageで一括対策
その他は$(.*).submitでgrepして$(this).prop("disabled",true);を前に追加

どのフォームでも登録中ボタンがdisabledになること