### PR TITLE
親のメニューに退会・休会のリンクを追加

### DIFF
--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -99,7 +99,7 @@ return [
  'mail_title_calendar_rest' => 'rest of the class schedule',
  'mail_title_calendar_absence' => 'schedule absent',
  'mail_title_calendar_delete' => 'schedule delete',
- 'warning_unsubscribe' => "If you unsubscribe, you will not be able to log in to the system. \nIn addition, all class schedules after the unsubscribed date will be canceled automatically.",
+ 'warning_unsubscribe' => "Please specify the cancellation date after today. \nPlease confirm here, and you will be withdrawn after approval of withdrawal. \n\nYou will not be able to log in to this system after withdrawing. \nAll classes scheduled after the day of withdrawal will be canceled automatically.",
  'confirm_unsubscribe' => "Do you want to send a unsubscribed request?",
  'confirm_unsubscribe_cancel' => "Do you want to cancel the unsubscribed request?",
  'confirm_recess' => "Do you want to send a recess request?",
@@ -144,6 +144,5 @@ return [
  "copyright" => "Copyright © Kunitachi, Hachioji, and Hino's private instruction schools SaKuRa One All Rights Reserved.",
  'message_restore_contents' => 'Previeous contents has been saved on systems. Can I restore now?',
  "info_signup" => "The URL for main registration will be sent to the email address you entered.",
- "already_signup" => "If you have already registered, please log in here to use", 
+ "already_signup" => "If you have already registered, please log in here to use",
  ];
-

--- a/resources/lang/ja/messages.php
+++ b/resources/lang/ja/messages.php
@@ -102,7 +102,7 @@ return [
   'mail_title_calendar_setting_confirm' => '繰り返し予定をご確認ください',
   'mail_title_calendar_setting_fix' => '繰り返し予定が確定しました',
   'mail_title_calendar_setting_cancel' => '繰り返し予定をキャンセルしました',
-  'warning_unsubscribe' => "退会日は1か月以降の日にちを指定してください。\n\n退会すると、システムへのログインができなくなります。\nなお、退会日以降の授業予定はすべて自動的にキャンセルとなります。",
+  'warning_unsubscribe' => "退会日は本日以降を指定してください。\nこちらで確認し、退会承認後、退会となります。\n\n退会後は、当システムへのログインができなくなります。\nなお、退会日以降の授業予定はすべて自動的にキャンセルとなります。",
   'confirm_unsubscribe' => "退会連絡を送信しますか？",
   'confirm_unsubscribe_cancel' => "退会連絡を取り消しますか？",
   'info_unsubscribe_cancel' => "退会連絡を取り消しました。",

--- a/resources/views/asks/forms/unsubscribe_form.blade.php
+++ b/resources/views/asks/forms/unsubscribe_form.blade.php
@@ -46,8 +46,8 @@
         <div class="input-group-prepend">
           <span class="input-group-text"><i class="fa fa-calendar"></i></span>
         </div>
-        <input type="text" id="start_date" name="start_date" class="form-control float-left" required="true" uitype="datepicker" placeholder="例：{{date('Y/m/d', strtotime('+1 month'))}}"
-          minvalue="{{date('Y/m/d', strtotime('+1 day'))}}"
+        <input type="text" id="start_date" name="start_date" class="form-control float-left" required="true" uitype="datepicker" placeholder="例：{{date('Y/m/d')}}"
+          minvalue="{{date('Y/m/d')}}"
         >
       </div>
     </div>

--- a/resources/views/managers/menu.blade.php
+++ b/resources/views/managers/menu.blade.php
@@ -81,7 +81,7 @@
       </li>
       <li class="nav-item">
         <a href="/{{$domain}}/{{$item->id}}/ask?list=unsubscribe" class="nav-link @if($view=="ask" && $list=="unsubscribe") active @endif">
-          <i class="fa fa-user-slash nav-icon"></i>
+          <i class="fa fa-times-circle nav-icon"></i>
           <p>
             退会連絡
             @if($unsubscribe_count > 0)

--- a/resources/views/parents/menu.blade.php
+++ b/resources/views/parents/menu.blade.php
@@ -37,31 +37,35 @@
         --}}
       </ul>
     </li>
+    @foreach($charge_students as $charge_student)
     <li class="nav-item has-treeview menu-open">
       <a href="#" class="nav-link">
-      <i class="nav-icon fa fa-users"></i>
+        <i class="fa fa-user-graduate nav-icon"></i>
       <p>
-        登録生徒
+        <ruby style="ruby-overhang: none">
+          <rb>{{$charge_student->student->name()}}</rb>
+          <rt>{{$charge_student->student->kana()}}</rt>
+        </ruby>
         <i class="right fa fa-angle-left"></i>
       </p>
       </a>
       <ul class="nav nav-treeview">
-        @foreach($charge_students as $charge_student)
         <li class="nav-item">
-        <a class="nav-link" href="/students/{{$charge_student->id}}" >
-          <i class="fa fa-user-graduate nav-icon"></i>
-          <p>
-            <ruby style="ruby-overhang: none">
-              <rb>{{$charge_student->student->name()}}</rb>
-              <rt>{{$charge_student->student->kana()}}</rt>
-            </ruby>
-            <span class="badge badge-{{config('status_style')[$charge_student->student->status]}} right">
-              {{$charge_student->student->status_name()}}
-            </span>
-          </p>
-        </a>
+          <a class="nav-link" href="/students/{{$charge_student->id}}" >
+            <i class="fa fa-file nav-icon"></i>
+            {{__('labels.details')}}
+          </a>
         </li>
-        @endforeach
+        <li class="nav-item">
+          <a class="nav-link" href="/students/{{$charge_student->id}}/recess" >
+            <i class="fa fa-pause-circle nav-icon"></i>{{__('labels.recess')}}{{__('labels.contact')}}
+          </a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="/students/{{$charge_student->id}}/unsubscribe" >
+            <i class="fa fa-times-circle nav-icon"></i>{{__('labels.unsubscribe')}}{{__('labels.contact')}}
+          </a>
+        </li>
       </ul>
       <ul class="nav nav-treeview">
         {{-- TODO 兄弟すべての申し込み内容を１ページで見たい場合に使う。
@@ -78,6 +82,7 @@
         --}}
       </ul>
     </li>
+    @endforeach
 </ul>
 @endsection
 @section('page_footer')


### PR DESCRIPTION
退会即日可能にする

親ログイン
　→サイドメニューの生徒ごとの退会リンク
　→サイドメニューの生徒ごとの休会リンク
