### PR TITLE
/api/info_mail_reply

### DIFF
--- a/app/Http/Middleware/RequestTrace.php
+++ b/app/Http/Middleware/RequestTrace.php
@@ -21,7 +21,7 @@ class RequestTrace
       $user_id = 0;
       \Log::warning("----RequestTrace start----");
       if(isset($user)) $user_id = $user->id;
-      ActionLog::add($user_id);
+      ActionLog::add($request, $user_id);
       \Log::warning("----RequestTrace end----");
       return $next($request);
     }

--- a/app/Http/Middleware/RequestTrace.php
+++ b/app/Http/Middleware/RequestTrace.php
@@ -19,8 +19,10 @@ class RequestTrace
     {
       $user = Auth::user();
       $user_id = 0;
+      \Log::warning("----RequestTrace start----");
       if(isset($user)) $user_id = $user->id;
       ActionLog::add($user_id);
+      \Log::warning("----RequestTrace end----");
       return $next($request);
     }
 }

--- a/app/Http/Middleware/RequestTrace.php
+++ b/app/Http/Middleware/RequestTrace.php
@@ -19,10 +19,8 @@ class RequestTrace
     {
       $user = Auth::user();
       $user_id = 0;
-      \Log::warning("----RequestTrace start----");
       if(isset($user)) $user_id = $user->id;
       ActionLog::add($request, $user_id);
-      \Log::warning("----RequestTrace end----");
       return $next($request);
     }
 }

--- a/app/Models/ActionLog.php
+++ b/app/Models/ActionLog.php
@@ -77,6 +77,7 @@ class ActionLog extends Model
       }
       $p = [];
       $data['session_id'] = Session::getId();
+      $data['login_user_id'] = 0;
       if($login_user_id!=null)  $data['login_user_id'] = $login_user_id;
       foreach($_POST as $key => $val){
         if($key=='password' || $key=='password_confirm') continue;

--- a/app/Models/ActionLog.php
+++ b/app/Models/ActionLog.php
@@ -63,12 +63,21 @@ class ActionLog extends Model
       $data['url'] = url()->full();
       $data['method'] = $_SERVER['REQUEST_METHOD'];
       $data['referer'] = url()->previous();
-      $data['client_ip'] = $_SERVER['REMOTE_ADDR'];
-      $data['user_agent'] = $_SERVER['HTTP_USER_AGENT'];
-      $data['language'] = $_SERVER['HTTP_ACCEPT_LANGUAGE'];
+      $data['client_ip'] = '-';
+      if(isset($_SERVER['REMOTE_ADDR'])){
+        $data['client_ip'] = $_SERVER['REMOTE_ADDR'];
+      }
+      $data['user_agent'] = '-';
+      if(isset($_SERVER['HTTP_USER_AGENT'])){
+        $data['user_agent'] = $_SERVER['HTTP_USER_AGENT'];
+      }
+      $data['language'] = '-';
+      if(isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])){
+        $data['language'] = $_SERVER['HTTP_ACCEPT_LANGUAGE'];
+      }
       $p = [];
       $data['session_id'] = Session::getId();
-      $data['login_user_id'] = $login_user_id;
+      if($login_user_id!=null)  $data['login_user_id'] = $login_user_id;
       foreach($_POST as $key => $val){
         if($key=='password' || $key=='password_confirm') continue;
         $p[$key] = $val;

--- a/app/Models/ActionLog.php
+++ b/app/Models/ActionLog.php
@@ -55,9 +55,10 @@ class ActionLog extends Model
     return $this->config_attribute_name('mail_status', $this->status);
   }
 
-  static protected function add($login_user_id=null){
+  static protected function add(Request $request, $login_user_id=null){
     $data = [];
     try {
+
       $data['server_name'] = $_SERVER['SERVER_NAME'];
       $data['server_ip'] = $_SERVER['SERVER_ADDR'];
       $data['url'] = url()->full();
@@ -79,7 +80,8 @@ class ActionLog extends Model
       $data['session_id'] = Session::getId();
       $data['login_user_id'] = 0;
       if($login_user_id!=null)  $data['login_user_id'] = $login_user_id;
-      foreach($_REQUEST as $key => $val){
+
+      foreach($request->all() as $key => $val){
         if($key=='password' || $key=='password_confirm') continue;
         $p[$key] = $val;
       }

--- a/app/Models/ActionLog.php
+++ b/app/Models/ActionLog.php
@@ -79,7 +79,7 @@ class ActionLog extends Model
       $data['session_id'] = Session::getId();
       $data['login_user_id'] = 0;
       if($login_user_id!=null)  $data['login_user_id'] = $login_user_id;
-      foreach($_POST as $key => $val){
+      foreach($_REQUEST as $key => $val){
         if($key=='password' || $key=='password_confirm') continue;
         $p[$key] = $val;
       }

--- a/app/Models/ActionLog.php
+++ b/app/Models/ActionLog.php
@@ -77,6 +77,7 @@ class ActionLog extends Model
       ActionLog::create($data);
     }
     catch(\Exception $e){
+      \Log::warning("ActionLog::add Exception Error (".$e->getMessage().")");
     }
   }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -12,11 +12,12 @@ use Illuminate\Http\Request;
 | is assigned the "api" middleware group. Enjoy building your API!
 |
 */
+Route::group(['middleware' => 'request.trace', 'prefix' => ''], function() {
+  Route::middleware('auth:api')->get('/user', function (Request $request) {
+      return $request->user();
+  });
 
-Route::middleware('auth:api')->get('/user', function (Request $request) {
-    return $request->user();
-});
-
-Route::group(['middleware' => ['api']], function () {
-    Route::post('info_mail_reply', 'MailLogController@info_mail_reply');
+  Route::group(['middleware' => ['api']], function () {
+      Route::post('info_mail_reply', 'MailLogController@info_mail_reply');
+  });
 });


### PR DESCRIPTION
必須パラメータにgmail_idを追加

api.phpにてaction_logsを出力するように対応

2重送信チェックロジック追加

同一宛先かつ、同一タイトルの場合2重送信とみなす

タイトルは、自動生成なので確実に管理可能となる