### PR TITLE
get_access_memberにuser_id引数を除去したことで、

### DIFF
--- a/app/Http/Controllers/UserCalendarController.php
+++ b/app/Http/Controllers/UserCalendarController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use App\User;
 use App\Models\Student;
 use App\Models\Teacher;
@@ -17,6 +18,7 @@ use App\Models\Ask;
 use App\Models\Trial;
 use DB;
 use View;
+
 class UserCalendarController extends MilestoneController
 {
   public $domain = 'calendars';
@@ -717,6 +719,9 @@ class UserCalendarController extends MilestoneController
         if (!View::exists($this->domain.'.'.$status)) {
           abort(404, 'ページがみつかりません(100)');
         }
+      }
+      else {
+        Auth::loginUsingId($request->get('user'));
       }
       $param = $this->page_access_check($request, $id);
       $param['ask'] = $this->get_ask_data($request, $param, $status);


### PR DESCRIPTION
ログインしていない場合に、エラーが発生する

非会員に対し予定確定するsimplepage(ログインせず操作可能）において、エラーが発生