### PR TITLE
Feature/583

### DIFF
--- a/app/Http/Controllers/ManagerController.php
+++ b/app/Http/Controllers/ManagerController.php
@@ -31,11 +31,11 @@ class ManagerController extends TeacherController
           abort(403);
         }
         $ret['item'] = $this->model()->where('id',$id)->first()->user->details($this->domain);
-        $count = $this->get_ask([], $ret['item']->user_id, true);
+        $count = $this->get_ask(['user_id'=>$ret['item']->user_id], true);
         $ret['ask_count'] = $count;
         $lists = ['lecture_cancel', 'teacher_change', 'recess', 'unsubscribe', 'phone'];
         foreach($lists as $list){
-          $count = $this->get_ask(["list" => $list], $ret['item']->user_id, true);
+          $count = $this->get_ask(["list" => $list, 'user_id'=> $ret['item']->user_id], true);
           $ret[$list.'_count'] = $count;
         }
       }

--- a/app/Http/Controllers/StudentController.php
+++ b/app/Http/Controllers/StudentController.php
@@ -6,6 +6,7 @@ use App\User;
 use App\Models\Student;
 use App\Models\StudentParent;
 use App\Models\UserCalendar;
+use App\Models\UserCalendarSetting;
 use App\Models\StudentRelation;
 use App\Models\GeneralAttribute;
 use App\Models\Ask;
@@ -85,10 +86,10 @@ class StudentController extends UserController
       }
       $lists = ['cancel', 'confirm', 'exchange', 'month', 'rest_contact'];
       foreach($lists as $list){
-        $count = $this->get_schedule(["list" => $list], $ret['item']->user_id, '', '', true);
+        $count = $this->get_schedule(["list" => $list, 'user_id' => $ret['item']->user_id],true);
         $ret[$list.'_count'] = $count;
       }
-      $count = $this->get_ask([], $ret['item']->user_id, true);
+      $count = $this->get_ask(['user_id'=>$ret['item']->user_id], true);
       $ret['ask_count'] = $count;
     }
     else {
@@ -408,7 +409,8 @@ class StudentController extends UserController
          'search_from_date' =>  $from_date,
          'search_to_date' =>  $to_date,
          'search_status' => ['fix'],
-       ], $param['item']->user_id);
+         'user_id' => $param['item']->user_id,
+       ]);
      $param['calendars'] = $calendars['data'];
      $view = 'asks.emergency_lecture_cancel';
      return view($view, [
@@ -474,7 +476,8 @@ class StudentController extends UserController
        'search_from_date' =>  $from_date,
        'search_to_date' =>  $to_date,
        'search_status' => ['fix'],
-     ], $param['item']->user_id);
+       'user_id' => $param['item']->user_id,
+     ]);
 
    $param['calendars'] = $calendars['data'];
    return view('asks.late_arrival', [])->with($param);
@@ -573,7 +576,9 @@ class StudentController extends UserController
 
 
    $view = "schedule";
-   $calendars = $this->get_schedule($request->all(), $item->user_id);
+   $form = $request->all();
+   $form['user_id'] = $item->user_id;
+   $calendars = $this->get_schedule($form);
    $calendars = $calendars["data"];
    $param['calendars'] = $calendars;
    $param['view'] = $view;
@@ -605,8 +610,9 @@ class StudentController extends UserController
    $item = $model->details();
    $item['tags'] = $model->tags();
    $user = $param['user'];
-
-   $asks = $this->get_ask($request->all(), $item->user_id);
+   $form = $request->all();
+   $form['user_id'] = $item->user_id;
+   $asks = $this->get_ask($form);
    $page_data = $this->get_pagedata($asks['count'] , $param['_line'], $param['_page']);
    foreach($page_data as $key => $val){
      $param[$key] = $val;
@@ -679,13 +685,18 @@ class StudentController extends UserController
    if($request->has('list')){
      $filter['list'] = $request->get('list');
    }
-   $calendar_settings = $this->get_calendar_settings($filter, $item->user_id);
+   $filter['user_id'] = $item->user_id;
+   $calendar_settings = $this->get_user_calendar_settings($filter);
    return view($this->domain.'.'.$view, [
      'calendar_settings' => $calendar_settings['data'],
    ])->with($param);
  }
- public function get_calendar_settings($form, $user_id, $is_count_only = false){
-   $user = User::where('id', $user_id)->first()->details();
+ public function get_user_calendar_settings($form, $is_count_only = false){
+   if(!isset($form['user_id'])) abort(403);
+   $cache_key = $this->create_cache_key(__FUNCTION__.'_count', $form);
+   $count = (new UserCalendarSetting())->get_user_cache($cache_key, $form['user_id']);
+   if($count != null && $is_count_only==true) return $count;
+   $user = User::where('id', $form['user_id'])->first()->details();
    if(!isset($form['list'])) $form['list'] = '';
    switch($form['list']){
      case "confirm_list":
@@ -704,6 +715,7 @@ class StudentController extends UserController
 
    $calendar_settings = $user->get_calendar_settings($form);
    $count = count($calendar_settings);
+   (new UserCalendarSetting())->put_user_cache($cache_key, $form['user_id'], $count);
    if($is_count_only == true) return $count;
    if(isset($form['_page']) && isset($form['_line'])){
      $calendar_settings = $calendar_settings->pagenation(intval($form['_page'])-1, $form['_line']);
@@ -711,16 +723,23 @@ class StudentController extends UserController
    //echo $calendars->toSql()."<br>";
    if($this->domain=='students'){
      foreach($calendar_settings as $i=>$setting){
-       $calendar_settings[$i] = $setting->details($user_id);
-       $calendar_settings[$i]->own_member = $setting[$i]->get_member($user_id);
+       $calendar_settings[$i] = $setting->details();
+       $calendar_settings[$i]->own_member = $setting[$i]->get_member();
        $calendar_settings[$i]->status = $setting[$i]->own_member->status;
      }
    }
    return ["data" => $calendar_settings, 'count' => $count];
  }
 
- public function get_schedule($form, $user_id, $from_date = '', $to_date = '', $is_count_only = false){
-   $user = User::where('id', $user_id)->first()->details();
+ public function get_schedule($form, $is_count_only = false){
+   if(!isset($form['user_id'])) abort(403);
+   $from_date = '';
+   $to_date = '';
+   $cache_key = $this->create_cache_key(__FUNCTION__.'_count', $form);
+   $count = (new UserCalendar())->get_user_cache($cache_key, $form['user_id']);
+   if($count != null && $is_count_only==true) return $count;
+
+   $user = User::where('id', $form['user_id'])->first()->details();
    $form['_sort'] ='start_time';
    $statuses = [];
    if(!isset($form['list'])) $form['list'] = '';
@@ -844,7 +863,7 @@ class StudentController extends UserController
    $calendars = $calendars->findWorks($works);
    $calendars = $calendars->findPlaces($places);
    $calendars = $calendars->findTeachingType($teaching_types);
-   $calendars = $calendars->findUser($user_id);
+   $calendars = $calendars->findUser($form['user_id']);
    if($is_exchange==true){
      \Log::warning("----------exchange-------------");
      $calendars = $calendars->findExchangeTarget();
@@ -853,6 +872,7 @@ class StudentController extends UserController
      $calendars = $calendars->searchWord($form['search_keyword']);
    }
    $count = $calendars->count();
+   (new UserCalendar())->put_user_cache($cache_key, $form['user_id'], $count);
    if($is_count_only==true) return $count;
    $calendars = $calendars->sortStarttime($sort);
 
@@ -865,16 +885,20 @@ class StudentController extends UserController
    //echo $calendars->toSql()."<br>";
    if($this->domain=='students'){
      foreach($calendars as $i=>$calendar){
-       $calendars[$i] = $calendar->details($user_id);
-       $calendars[$i]->own_member = $calendars[$i]->get_member($user_id);
+       $calendars[$i] = $calendar->details();
+       $calendars[$i]->own_member = $calendars[$i]->get_member();
        $calendars[$i]->status = $calendars[$i]->own_member->status;
      }
    }
 
-
    return ["data" => $calendars, 'count' => $count];
  }
- public function get_ask($form, $user_id, $is_count_only = false){
+ public function get_ask($form, $is_count_only = false){
+   if(!isset($form['user_id'])) abort(403);
+   $cache_key = $this->create_cache_key(__FUNCTION__.'_count', $form);
+   $count = (new Ask())->get_user_cache($cache_key, $form['user_id']);
+   if($count != null && $is_count_only==true) return $count;
+
    if(!isset($form['list'])) $form['list'] = '';
    $default_status = 'new';
    switch($form['list']){
@@ -938,11 +962,12 @@ class StudentController extends UserController
    }
    $asks = Ask::findStatuses($statuses);
    $asks = $asks->findTypes($types);
-   $u = User::where('id', $user_id)->first()->details('managers');
+   $u = User::where('id', $form['user_id'])->first()->details('managers');
    if($this->domain!="managers" || !$this->is_manager($u->role)){
-     $asks = $asks->findUser($user_id);
+     $asks = $asks->findUser($form['user_id']);
    }
    $count = $asks->count();
+   (new Ask())->put_user_cache($cache_key, $form['user_id'], $count);
    if($is_count_only==true) return $count;
    $asks = $asks->sortEnddate($sort);
 

--- a/app/Http/Controllers/TeacherController.php
+++ b/app/Http/Controllers/TeacherController.php
@@ -46,19 +46,19 @@ class TeacherController extends StudentController
       $ret['item'] = $this->model()->where('id',$id)->first()->user->details($this->domain);
       $lists = ['cancel', 'confirm', 'exchange', 'today', 'rest_contact'];
       foreach($lists as $list){
-        $count = $this->get_schedule(["list" => $list], $ret['item']->user_id, '', '', true);
+        $count = $this->get_schedule(["list" => $list, 'user_id'=>$ret['item']->user_id] , true);
         $ret[$list.'_count'] = $count;
       }
-      $asks = $this->get_ask([], $ret['item']->user_id, true);
+      $asks = $this->get_ask(['user_id' => $ret['item']->user_id], true);
       $ret['ask_count'] = $count;
       $lists = ['lecture_cancel', 'rest_cancel'];
       foreach($lists as $list){
-        $count = $this->get_ask(["list" => $list], $ret['item']->user_id, true);
+        $count = $this->get_ask(["list" => $list, 'user_id'=>$ret['item']->user_id], true);
         $ret[$list.'_count'] = $count;
       }
       $lists = ['confirm_list', 'fix_list'];
       foreach($lists as $list){
-        $count = $this->get_calendar_settings(["list" => $list], $ret['item']->user_id, true);
+        $count = $this->get_user_calendar_settings(["list" => $list, 'user_id'=>$ret['item']->user_id], true);
         $ret[$list.'_setting_count'] = $count;
       }
 
@@ -437,8 +437,12 @@ class TeacherController extends StudentController
       ]);
       $from_date = $target_month.'-01';
       $to_date = date("Y-m-d", strtotime("+1 month ".$from_date));
-
-      $calendars = $this->get_schedule([], $item->user_id, $from_date, $to_date);
+      $calendars = $this->get_schedule([
+        'list' => 'month_work',
+        'user_id'=>$item->user_id,
+        'search_from_date' => $from_date,
+        'search_to_date' => $to_date
+      ]);
       $param["_maxpage"] = floor($calendars["count"] / $param['_line']);
       $calendars = $calendars["data"];
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -410,5 +410,11 @@ class UserController extends Controller
   public function user_login($user_id){
     Auth::loginUsingId($user_id);
   }
-
+  public function create_cache_key($prefix, $param){
+    $cache_key = $prefix.'_';
+    foreach($param as $key=>$val){
+      $cache_key .= '['.$key.'='.$val.']';
+    }
+    return $cache_key;
+  }
 }

--- a/app/Models/Ask.php
+++ b/app/Models/Ask.php
@@ -10,8 +10,11 @@ use App\Models\Teachers;
 use App\Models\Students;
 use App\Models\UserCalendarMember;
 use View;
+use App\Models\Traits\WebCache;
+
 class Ask extends Milestone
 {
+  use WebCache;
   protected $table = 'lms.asks';
   protected $guarded = array('id');
 
@@ -155,6 +158,7 @@ EOT;
       'target_user_id' => $form['target_user_id'],
       'create_user_id' => $form['create_user_id'],
     ]);
+    $ask->cache_delete();
     if($ask->is_auto_commit()==true){
       //自動承認対象
       \Log::warning("自動承実行");
@@ -175,6 +179,7 @@ EOT;
     if(isset($form["status"]) && isset($form["login_user_id"])){
       $this->_change($form);
       $this->update(['status'=>$form['status']]);
+      $this->cache_delete();
     }
     return $this;
   }
@@ -182,6 +187,7 @@ EOT;
     $target_model = null;
     AskComment::where('ask_id', $this->id)->delete();
     $this->delete();
+    $this->cache_delete();
   }
   public function end_dateweek(){
     $d = date('n月j日',  strtotime($this->end_date));
@@ -468,5 +474,9 @@ EOT;
       if(isset($s) && $s->is_parent($u->id)==true) return true;
     }
     return false;
+  }
+  public function cache_delete(){
+    $this->delete_user_cache($this->charge_user_id);
+    $this->delete_user_cache($this->target_user_id);
   }
 }

--- a/app/Models/Traits/WebCache.php
+++ b/app/Models/Traits/WebCache.php
@@ -1,0 +1,25 @@
+<?php
+namespace App\Models\Traits;
+use Illuminate\Support\Facades\Cache;
+
+trait WebCache
+{
+
+  public funtion _cache_get($key)
+  {
+    if(Cache::has($key)){
+      return Cache::get($key);
+    }
+    return null;
+  }
+  public funtion _cache_put($key, $user_id, $data, $minutes=60)
+  {
+    Cache::tags([$this->table, 'user_id='.$user_id])->put($key, $data, $minutes);
+  }
+  public funtion _user_cache_delete($user_id)
+  {
+    Cache::tags([$this->table, 'user_id='.$user_id])->flush();
+  }
+  public function CacheDelete(){
+  }
+}

--- a/app/Models/Traits/WebCache.php
+++ b/app/Models/Traits/WebCache.php
@@ -4,22 +4,84 @@ use Illuminate\Support\Facades\Cache;
 
 trait WebCache
 {
-
-  public funtion _cache_get($key)
-  {
-    if(Cache::has($key)){
-      return Cache::get($key);
+  protected $default_expired_minutes = 60;
+  public function get_user_cache($cache_key, $save_id){
+    try {
+      return $this->get_cache($cache_key, 'user_id='.$save_id);
+    }
+    catch(\Exception $e){
+      Cache::flush();
+    }
+  }
+  public function put_user_cache($cache_key, $save_id, $data){
+    try {
+      return $this->put_cache($cache_key, 'user_id='.$save_id, $data);
+    }
+    catch(\Exception $e){
+      Cache::flush();
+    }
+  }
+  public function delete_user_cache($save_id){
+    try {
+      return $this->delete_cache('user_id='.$save_id);
+    }
+    catch(\Exception $e){
+      Cache::flush();
+    }
+  }
+  /*
+    キャッシュの保存形式
+     1．保存するキー名＝prefix+id (ex. prefix:"user_id=" , id:"123")
+     2．保存するデータの形式  = [$table_name][$save_item_name] = $save_data
+        DB更新時に、削除するキャッシュの単位は、テーブル単位で行う
+     3. 保存期限＝デフォルト　1時間
+  */
+  private function get_cache($cache_key, $save_id){
+    if(Cache::has($save_id)){
+      $_cache = Cache::get($save_id);
+      if(!isset($_cache['expired'])) {
+        //期限設定がないCacheは削除
+        Cache::forget($save_id);
+        return null;
+      }
+      if(strtotime('now') > $_cache['expired']){
+        //期限切れ
+        Cache::forget($save_id);
+        return null;
+      }
+      if(!isset($_cache[$this->table])) return null;
+      if(!isset($_cache[$this->table][$cache_key])) return null;
+      return $_cache[$this->table][$cache_key];
     }
     return null;
   }
-  public funtion _cache_put($key, $user_id, $data, $minutes=60)
-  {
-    Cache::tags([$this->table, 'user_id='.$user_id])->put($key, $data, $minutes);
+  private function put_cache($cache_key, $save_id, $data){
+    $_cache = [];
+    if(Cache::has($save_id)){
+      $_cache = Cache::get($save_id);
+      //期限切れ　Cacheデータを持ち越さずに作る
+      if(isset($_cache['expired']) && strtotime('now') > $_cache['expired']){
+        $_cache = [];
+      }
+    }
+    if(!isset($_cache[$this->table])) $_cache[$this->table] = [];
+    $_cache[$this->table][$cache_key] = $data;
+    //期限設定
+    $_cache['expired'] = strtotime('+ '.$this->default_expired_minutes.' minute');
+    Cache::put($save_id, $_cache, $this->default_expired_minutes);
   }
-  public funtion _user_cache_delete($user_id)
-  {
-    Cache::tags([$this->table, 'user_id='.$user_id])->flush();
-  }
-  public function CacheDelete(){
+  private function delete_cache($save_id){
+    $_cache = [];
+    if(Cache::has($save_id)){
+      $_cache = Cache::get($save_id);
+      //期限切れ　Cacheデータそのものを削除
+      if(isset($_cache['expired']) && strtotime('now') > $_cache['expired']){
+        Cache:forget($save_id);
+        return ;
+      }
+      //$this->tableのデータを削除
+      if(isset($_cache[$this->table])) $_cache[$this->table] = [];
+      Cache::put($save_id, $_cache, $this->default_expired_minutes);
+    }
   }
 }

--- a/app/Models/UserCalendar.php
+++ b/app/Models/UserCalendar.php
@@ -16,10 +16,12 @@ use App\User;
 use DB;
 
 use App\Models\Traits\Common;
+use App\Models\Traits\WebCache;
 
 class UserCalendar extends Model
 {
   use Common;
+  use WebCache;
   protected $pagenation_line = 20;
   protected $table = 'lms.user_calendars';
   protected $guarded = array('id');
@@ -804,6 +806,7 @@ EOT;
       $this->delete_mail([], $login_user_id);
     }
     //事務システム側を先に削除
+    $this->cache_delete();
     $this->office_system_api("DELETE");
     UserCalendarMember::where('calendar_id', $this->id)->delete();
     UserCalendarTag::where('calendar_id', $this->id)->delete();
@@ -875,6 +878,7 @@ EOT;
       }
     }
     //事務システムも更新
+    $this->cache_delete();
     $this->office_system_api("PUT");
 
     if(isset($form['send_mail'])){
@@ -1100,118 +1104,6 @@ EOT;
   public function is_kids_lesson(){
     return $this->has_tag('lesson', 4);
   }
-  /*
-  public function status_to_confirm($remark, $login_user_id){
-    if($this->status!='new') return false;
-    $status = 'confirm';
-    foreach($this->members as $member){
-      if(!isset($member->user)) continue;
-      $_member = $member->user->details('students');
-      if($_member->role != 'student') continue;
-    }
-    $this->update(['status' => $status]);
-
-  }
-
-  public function status_to_fix($remark, $login_user_id){
-    if($this->status!='new' && $this->status!='confirm' && $this->status!='cancel') return false;
-    $is_update = true;
-    foreach($this->members as $member){
-      if(!isset($member->user)) continue;
-      $_member = $member->user->details('students');
-      if($_member->role != 'student') continue;
-      if($member->status!='fix' && $member->status!='cancel'){
-        //fix or cancel以外があれば全体更新なし
-        $is_update = false;
-      }
-    }
-    if($is_update){
-      //全員キャンセル or 一人以上出席
-      $this->update(['status' => 'fix']);
-    }
-  }
-  public function status_to_cancel($remark, $login_user_id){
-    if($this->status!='confirm' && $this->status!='fix') return false;
-    $status = 'cancel';
-    $is_update = true;
-    foreach($this->members as $member){
-      if(!isset($member->user)) continue;
-      $_member = $member->user->details('students');
-      if($_member->role != 'student') continue;
-      if($member->status!='fix' && $member->status!='cancel'){
-        //fix or cancel以外があれば全体更新なし
-        $is_update = false;
-      }
-      if($member->status=='fix'){
-        //fix が1つ以上あれば fix
-        $status='fix';
-      }
-    }
-    if($is_update){
-      //全員キャンセル or 一人以上出席
-      $this->update(['status' => $status]);
-    }
-  }
-  public function status_to_rest($remark, $login_user_id){
-    if($this->status != 'fix') return false;
-    $status = 'rest';
-    $is_update = true;
-    foreach($this->members as $member){
-      if(!isset($member->user)) continue;
-      $_member = $member->user->details('students');
-      if($_member->role != 'student') continue;
-      if($member->status!='rest'){
-        //fix or cancel以外があれば全体更新なし
-        $is_update = false;
-      }
-    }
-    if($is_update){
-      //全員休んだらカレンダー休み
-      $this->update(['status' => $status]);
-    }
-  }
-  public function status_to_absence($remark, $login_user_id){
-    //授業予定→出席、　出席（間違えた場合）→欠席
-    if($this->status!='fix' && $this->status!="presence") return false;
-    $status = 'absence';
-    //カレンダー：欠席
-    $is_update = true;
-    \Log::warning("-------status_to_absence----------");
-    foreach($this->members as $member){
-      if(!isset($member->user)) continue;
-      $_member = $member->user->details('students');
-      \Log::warning("status:".$member->status);
-      if($_member->role == 'student' && $member->is_rest_status($member->status)!=true){
-        $is_update = false;
-      }
-    }
-    if($is_update == true){
-      \Log::warning("-------is_update----------");
-      $this->update(['status' => $status]);
-    }
-  }
-  public function status_to_presence(){
-    //授業予定→出席、　欠席（間違えた場合）→出席
-    if($this->status!='fix' && $this->status!="absence") return false;
-    $status = 'presence';
-    $is_update = false;
-    \Log::warning("-------status_to_presence----------");
-    //カレンダー：出席
-    foreach($this->members as $member){
-      if(!isset($member->user)) continue;
-      $_member = $member->user->details('students');
-      \Log::warning("status:".$member->status);
-      if($_member->role == 'student' && $member->status=='presence'){
-        $is_update = true;
-      }
-    }
-    //出席者が一人でもいたら、出席
-    if($is_update == true){
-      \Log::warning("-------is_update----------");
-      $this->update(['status' => $status]);
-    }
-  }
-  */
   public function exist_rest_student(){
     //欠席 or 休み or　休講
     foreach($this->members as $member){
@@ -1312,6 +1204,7 @@ EOT;
       }
     }
     if($this->status != $status){
+      $this->cache_delete();
       UserCalendar::where('id', $this->id)->update(['status' => $status]);
     }
     $this->set_endtime_for_single_group();
@@ -1346,4 +1239,11 @@ EOT;
     }
     return false;
   }
+  public function cache_delete(){
+    $this->delete_user_cache($this->user_id);
+    foreach($this->members as $member){
+      $this->delete_user_cache($member->user_id);
+    }
+  }
+
 }

--- a/app/Models/UserCalendarSetting.php
+++ b/app/Models/UserCalendarSetting.php
@@ -8,10 +8,12 @@ use App\Models\UserCalendar;
 use App\Models\UserCalendarMemberSetting;
 use DB;
 use App\Models\Traits\Common;
+use App\Models\Traits\WebCache;
 
 class UserCalendarSetting extends UserCalendar
 {
   use Common;
+  use WebCache;
   protected $table = 'lms.user_calendar_settings';
   protected $guarded = array('id');
   public $register_mail_template = 'calendar_setting_new';
@@ -332,6 +334,7 @@ EOT;
     }
 
     //事務システム側を先に削除
+    $this->cache_delete();
     $this->office_system_api("DELETE");
     UserCalendarTagsetting::where('user_calendar_setting_id', $this->id)->delete();
     UserCalendarMemberSetting::where('user_calendar_setting_id', $this->id)->delete();
@@ -406,6 +409,7 @@ EOT;
       }
       */
     }
+    $this->cache_delete();
     UserCalendarSetting::where('id', $this->id)->update($data);
     $tag_names = ['course_type', 'lesson', 'is_online'];
     foreach($tag_names as $tag_name){


### PR DESCRIPTION
〇動作確認
・講師詳細を開く
　①初回アクセス時より、２回目以降のアクセス速度がよくなる
　②講師単位にキャッシュは取るので、別の講師アクセス時でも同様に初回アクセスが遅く、２回目以降に早くなる
　③更新時、予定削除や、振替登録などで件数が変わった場合も画面上正しい件数になる

〇修正詳細
StudentController　
TeacherController
ManagerController
　get_schedule / get_user_calendar_settings / get_ask
 このメソッドのカウント取得する際、キャッシュに保存する（サイドメニューのせいで参照頻度が多い）

 StudentController::get_calendar_settings →　StudentController::get_user_calendar_settings
 (名前が紛らわしいので改名）
　　各メソッドで、引数を統一する（呼び出し元も修正）

UserController
　create_cache_key :　保存するキャッシュのitem名を生成する　関数名＋パラメータ

Ask
UserCalendar
UserCalendarSetting
 WebCache.phpを利用する
　各更新処理にて、delete_user_cacheを実行する

