### PR TITLE
単元の削除に伴うタスクとの紐づけ解除処理追加

### DIFF
--- a/app/Models/Curriculum.php
+++ b/app/Models/Curriculum.php
@@ -17,7 +17,7 @@ class Curriculum extends Milestone
     }
 
     public function tasks(){
-      return $this->belongsToMany('App\Models\Subject','task_curriculum','task_id','curriculum_id')->withTimestamps();
+      return $this->belongsToMany('App\Models\Task','task_curriculum','curriculum_id','task_id')->withTimestamps();
     }
 
 
@@ -37,6 +37,7 @@ class Curriculum extends Milestone
 
     public function dispose(){
       $this->subjects()->detach();
+      $this->tasks()->detach();
       $this->delete();
       return $this;
     }


### PR DESCRIPTION
Curriculum
 リレーション先のモデル記述が間違っていたので修正
　dispose時にtasksとのリレーションも解除するように修正