### PR TITLE
タスクの入力フォーム改善

### DIFF
--- a/app/Http/Controllers/MessageController.php
+++ b/app/Http/Controllers/MessageController.php
@@ -1,14 +1,14 @@
 <?php
 
 namespace App\Http\Controllers;
-
+use App;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
 use App\Models\Student;
 use App\Models\Message;
 use App\Models\Teacher;
 use App\Models\StudentParent;
 use App\Models\Manager;
-
 
 class MessageController extends CommentController
 {
@@ -179,8 +179,10 @@ class MessageController extends CommentController
           }else{
             $title_of_honor = "さん";
           }
-
+          App::setLocale($item->target_user->locale);
           $item->target_user->send_mail(__('messages.message_title',['user_name' => $item->create_user->details()->name(),'title_of_honor' => $title_of_honor]), $param, $type ,$template);
+          $u = Auth::user();
+          if(isset($u)) App::setLocale($u->locale);
         }
       }
       return $res;

--- a/resources/lang/en/labels.php
+++ b/resources/lang/en/labels.php
@@ -392,4 +392,6 @@ return [
   'actionlogs' => 'System Logs',
   'ask_teacher_change_description' => 'About teacher change you should check',
   'teacher_change' => 'Change assigned teacher',
-  'dummy_release' => 'Dummy Release',];
+  'dummy_release' => 'Dummy Release',
+  'task_title' => 'ex: English_selfIntroduction',
+];

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -152,4 +152,5 @@ return [
  "already_signup" => "If you have already registered, please log in here to use",
  'info_mail_reply' => 'You cannot reply to this email address',
  'confirm_dummy_release' => 'Do you want to release the dummy status?',
+ 'mail_reply_recomend' => '※If you want to reply, you should use SaKuRa One Net.',
  ];

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -152,5 +152,5 @@ return [
  "already_signup" => "If you have already registered, please log in here to use",
  'info_mail_reply' => 'You cannot reply to this email address',
  'confirm_dummy_release' => 'Do you want to release the dummy status?',
- 'mail_reply_recomend' => '※If you want to reply, you should use SaKuRa One Net.',
+ 'mail_reply_recomend' => "＊This e-mail is for sending only, so we cannot reply to you. \n＊If you want to reply, you should use SaKuRa One Net.",
  ];

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -144,6 +144,7 @@ return [
  'task_status_progress' => 'A status of this task is updated to [progress]',
  'task_status_done' => 'A status of this task is updated to [done]',
  'task_reviewed' => 'Reviewed',
+ 'task_body_placeholder' => 'ex. We tried new idiom. So, I think go ahead to next curriculum. ',
  'warning_schedule_add' => 'This additional class requires an additional tuition fee and must be approved by the parent.',
  "copyright" => "Copyright © Kunitachi, Hachioji, and Hino's private instruction schools SaKuRa One All Rights Reserved.",
  'message_restore_contents' => 'Previeous contents has been saved on systems. Can I restore now?',

--- a/resources/lang/ja/labels.php
+++ b/resources/lang/ja/labels.php
@@ -393,4 +393,5 @@ return [
   'ask_teacher_change_description' => '承認が必要な代講依頼',
   'teacher_change' => '講師変更',
   'dummy_release' => 'ダミーを解除する',
+  'task_title' => '例：算数_分数の足し算',
 ];

--- a/resources/lang/ja/messages.php
+++ b/resources/lang/ja/messages.php
@@ -156,5 +156,6 @@ return [
   "already_signup" => "すでに本登録済みの方は、\n<a href='/login'>こちら</a>からログインしてご利用ください",
   'info_mail_reply' => 'このメールアドレスへの返信はできません',
   'confirm_dummy_release' => 'ダミーステータスを解除しますか？',
+  'mail_reply_recomend' => '※ご返信は、SaKuRa One Netのメッセージ一覧をご利用ください。',
 
 ];

--- a/resources/lang/ja/messages.php
+++ b/resources/lang/ja/messages.php
@@ -156,6 +156,6 @@ return [
   "already_signup" => "すでに本登録済みの方は、\n<a href='/login'>こちら</a>からログインしてご利用ください",
   'info_mail_reply' => 'このメールアドレスへの返信はできません',
   'confirm_dummy_release' => 'ダミーステータスを解除しますか？',
-  'mail_reply_recomend' => '※ご返信は、SaKuRa One Netのメッセージ一覧をご利用ください。',
+  'mail_reply_recomend' => "＊本メールは送信専用ですので、ご返信できません。\n＊ご返信は、SaKuRa One Netのメッセージ一覧をご利用ください。",
 
 ];

--- a/resources/lang/ja/messages.php
+++ b/resources/lang/ja/messages.php
@@ -148,6 +148,7 @@ return [
   'task_status_progress' => 'タスクを着手中にしました。',
   'task_status_done' => 'タスクを完了しました。',
   'task_reviewed' => 'レビューしました。',
+  'task_body_placeholder' => '例：応用問題にチャレンジしましたが、難しいようでした。基本問題を解きなおします。',
   'warning_schedule_add' => 'この授業追加は、受講料の追加を伴うため、親御様の承認を得る必要があります。',
   "copyright" => "Copyright © 国立・八王子・日野の個別指導塾 さくら One All Rights Reserved.",
   'message_restore_contents' => '前回入力された内容が残っています。復元しますか？',

--- a/resources/views/curriculums/components/select_list.blade.php
+++ b/resources/views/curriculums/components/select_list.blade.php
@@ -1,5 +1,5 @@
     <label>{{__('labels.curriculums_name')}}</label>
-    <span class="right badge badge-secondary ml-1">{{__('labels.optional')}}</span>
+    <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
     {{--新規カリキュラム追加は別画面でやる。要望に備えてコメントアウト
     <a href="javascript:void(0);" id="add_curriculum" class="btn btn-default btn-sm ml-1" title="{{__('labels.curriculums').__('labels.add_button')}}">
       <i class="fa fa-plus"></i>
@@ -8,7 +8,7 @@
       <i class="fa fa-trash"></i>
     </a>
     --}}
-    <select name="curriculum_ids[]" class="form-control select2" id="select_curriculum" width=100%  multiple="multiple">
+    <select name="curriculum_ids[]" class="form-control select2" id="select_curriculum" width=100%  multiple="multiple" required="true">
       @foreach($curriculums as $curriculum)
       <option value="{{$curriculum->id}}"
       @if(!empty($item) && $_edit)
@@ -24,5 +24,8 @@
       $("#clear_curriculum").on('click', function(e){
         console.log('hoge');
         $('#new_curriculums').empty();
+      });
+      $("#select_curriculum").on('change', function(e){
+        set_title();
       });
     </script>

--- a/resources/views/emails/message_text.blade.php
+++ b/resources/views/emails/message_text.blade.php
@@ -2,15 +2,13 @@
 
 
 @if($item->target_user->details()->role == "parent" || $item->target_user->details()->role == "student")
-{{__('messages.mail_dear',['user_name' => $item->target_user->details()->name])}}
+{{__('messages.mail_dear',['user_name' => $item->target_user->details()->name])}} {{__('messages.message_first_sentence')}}
 @elseif($item->target_user->details()->role == "teacher")
-{{__('messages.mail_dear_teacher',['user_name' => $item->target_user->details()->name])}}
+{{__('messages.mail_dear_teacher',['user_name' => $item->target_user->details()->name])}} {{__('messages.message_first_sentence')}}
 @elseif($item->target_user->details()->role == "manager")
-{{__('messages.mail_dear_manager',['user_name' => $item->target_user->details()->name])}}
+{{__('messages.mail_dear_manager',['user_name' => $item->target_user->details()->name])}} {{__('messages.message_first_sentence')}}
 @endif
 
-{{__('messages.message_first_sentence')}}
-{{__('messages.mail_auto_send_message')}}
 {{__('messages.mail_reply_recomend')}}
 {{config('app.url')}}/login
 

--- a/resources/views/emails/message_text.blade.php
+++ b/resources/views/emails/message_text.blade.php
@@ -10,10 +10,10 @@
 @endif
 
 {{__('messages.message_first_sentence')}}
-【{{__('labels.important')}}】
 {{__('messages.mail_auto_send_message')}}
 {{__('messages.mail_reply_recomend')}}
 {{config('app.url')}}/login
+
 --------------------------------------
 {{__('labels.message_title')}}:
 {{$item->title}}

--- a/resources/views/emails/message_text.blade.php
+++ b/resources/views/emails/message_text.blade.php
@@ -1,8 +1,5 @@
 @include('emails.common')
 
-【{{__('labels.important')}}】
-{{__('messages.mail_auto_send_message')}}
-{{__('messages.mail_reply_recomend')}}
 
 @if($item->target_user->details()->role == "parent" || $item->target_user->details()->role == "student")
 {{__('messages.mail_dear',['user_name' => $item->target_user->details()->name])}}
@@ -13,6 +10,10 @@
 @endif
 
 {{__('messages.message_first_sentence')}}
+【{{__('labels.important')}}】
+{{__('messages.mail_auto_send_message')}}
+{{__('messages.mail_reply_recomend')}}
+{{config('app.url')}}/login
 --------------------------------------
 {{__('labels.message_title')}}:
 {{$item->title}}

--- a/resources/views/emails/message_text.blade.php
+++ b/resources/views/emails/message_text.blade.php
@@ -1,5 +1,9 @@
 @include('emails.common')
 
+【{{__('labels.important')}}】
+{{__('messages.mail_auto_send_message')}}
+{{__('messages.mail_reply_recomend')}}
+
 @if($item->target_user->details()->role == "parent" || $item->target_user->details()->role == "student")
 {{__('messages.mail_dear',['user_name' => $item->target_user->details()->name])}}
 @elseif($item->target_user->details()->role == "teacher")

--- a/resources/views/messages/create.blade.php
+++ b/resources/views/messages/create.blade.php
@@ -12,21 +12,23 @@
         <label>To</label>
         @if($_reply == false)
         <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
-        <select name="target_user_id[]" class="form-control select2" width="100%" multiple="multiple">
-          <option value=" "></option>
-          @foreach($charge_users as $target_user)
-            <option value="{{$target_user->user_id}}">{{$target_user->name_last}} {{$target_user->name_first}}</option>
-          @endforeach
-        </select>
-        @else
-          @if($item->create_user_id == $user->user_id)
-          {{$item->target_user->details()->name()}}
-          <input type="hidden" name="target_user_id[]" value="{{$item->target_user_id}}">
+        <div class="form-group w-100">
+          <select name="target_user_id[]" class="form-control select2" width="100%" multiple="multiple" required="true">
+            <option value=" "></option>
+            @foreach($charge_users as $target_user)
+              <option value="{{$target_user->user_id}}">{{$target_user->name_last}} {{$target_user->name_first}}</option>
+            @endforeach
+          </select>
           @else
-          {{$item->create_user->details()->name()}}
-          <input type="hidden" name="target_user_id[]" value="{{$item->create_user_id}}">
+            @if($item->create_user_id == $user->user_id)
+            {{$item->target_user->details()->name()}}
+            <input type="hidden" name="target_user_id[]" value="{{$item->target_user_id}}">
+            @else
+            {{$item->create_user->details()->name()}}
+            <input type="hidden" name="target_user_id[]" value="{{$item->create_user_id}}">
+            @endif
           @endif
-        @endif
+        </div>
       </div>
       <div class="col-12 mt-2">
          <div class="form-group">

--- a/resources/views/tasks/create.blade.php
+++ b/resources/views/tasks/create.blade.php
@@ -59,13 +59,20 @@
           <label>{{__('labels.title')}}</label>
           <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
           <div class="input-group mb-3">
-            <input type="text" class="form-control" name="title" id="title" placeholder="{{__('labels.title')}}" required="true" value="{{$_edit ? $item->title : ''}}" maxlength=255>
+            <input type="text" class="form-control" name="title" id="title" placeholder="{{__('labels.task_title')}}" required="true" value="{{$_edit ? $item->title : ''}}" maxlength=255>
             <div class="input-group-append">
               <button class="btn btn-info" type="button" id="title_set">
                 <i class="fa fa-copy"></i>
               </button>
             </div>
           </div>
+        </div>
+      </div>
+      <div class="row mt-2">
+        <div class="col-12">
+          <label>{{__('labels.tasks_remarks')}}</label>
+          <span class="right badge badge-secondary ml-1">{{__('labels.optional')}}</span>
+          <textarea name="body" class="form-control" placeholder="{{__('messages.task_body_placeholder')}}" >{{$_edit ? $item->body : ''}}</textarea>
         </div>
       </div>
       <div class="row mt-2">
@@ -103,13 +110,6 @@
           @endif
         </div>
 
-        <div class="row mt-2">
-          <div class="col-12">
-            <label>{{__('labels.tasks_remarks')}}</label>
-            <span class="right badge badge-secondary ml-1">{{__('labels.optional')}}</span>
-            <textarea name="body" class="form-control" placeholder="{{__('labels.tasks_remarks')}}" >{{$_edit ? $item->body : ''}}</textarea>
-          </div>
-        </div>
         <div class="row mt-2">
           <div class="col-6">
             <label>{{__('labels.start_schedule')}}</label>
@@ -204,9 +204,14 @@
   $("#select_subject").on('change', function(e){
     $('#curriculums').load( "{{url('/curriculums/get_select_list')}}?subject_id="+$('select#select_subject').val(),function(){
       base.pageSettinged('create_tasks');
+      set_title();
     });
   });
   $("#title_set").on('click', function(e){
+    set_title();
+  });
+
+  function set_title(){
     var curriculums = "";
     $("#select_curriculum option:selected").each(function(){
       curriculums += "_" + $(this).text();
@@ -216,7 +221,7 @@
     });
     var title = $("#select_subject option:selected" ).text().trim() +  curriculums;
     $("#title").val(title);
-  });
+  }
 
 
   </script>

--- a/resources/views/tasks/create.blade.php
+++ b/resources/views/tasks/create.blade.php
@@ -60,11 +60,18 @@
           <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
           <div class="input-group mb-3">
             <input type="text" class="form-control" name="title" id="title" placeholder="{{__('labels.task_title')}}" required="true" value="{{$_edit ? $item->title : ''}}" maxlength=255>
+            {{--タイトル変更系のボタンは封印
             <div class="input-group-append">
               <button class="btn btn-info" type="button" id="title_set">
                 <i class="fa fa-copy"></i>
               </button>
             </div>
+            <div class="input-group-append">
+              <button class="btn btn-danger" type="button" id="clear_title">
+                <i class="fa fa-times-circle"></i>
+              </button>
+            </div>
+            --}}
           </div>
         </div>
       </div>
@@ -202,13 +209,22 @@
   });
 
   $("#select_subject").on('change', function(e){
-    $('#curriculums').load( "{{url('/curriculums/get_select_list')}}?subject_id="+$('select#select_subject').val(),function(){
-      base.pageSettinged('create_tasks');
-      set_title();
-    });
+    if(this.value == ' '){
+      console.log(this.value);
+      $("#curriculums").empty();
+    }else{
+      $('#curriculums').load( "{{url('/curriculums/get_select_list')}}?subject_id="+$('select#select_subject').val(),function(){
+        base.pageSettinged('create_tasks');
+        set_title();
+      });
+    }
   });
   $("#title_set").on('click', function(e){
     set_title();
+  });
+
+  $('#clear_title').on('click',function(e){
+    $('#title').val("");
   });
 
   function set_title(){


### PR DESCRIPTION
・概要のガイドを変更する
→(科目)_(単元)　で入れてもらえるように
・詳細のガイドを変更する
→授業の様子などを入れてもらえるように
・詳細を最初から表示する
→概要に授業の様子が入っているので、詳細を利用してもらえるように
・科目、単元変更時に概要を自動入力する

・科目選択時に単元を選ばないと登録できない