### PR TITLE
勤務設定に季節講習・場所を追加

### DIFF
--- a/app/Models/Student.php
+++ b/app/Models/Student.php
@@ -331,6 +331,8 @@ EOT;
       'kana_first' => "",
       'birth_day' => "9999-12-31",
       'gender' => "",
+      'entry_date' => null,
+
     ];
     $update_form = [];
     foreach($update_field as $key => $val){

--- a/app/Models/Teacher.php
+++ b/app/Models/Teacher.php
@@ -114,8 +114,11 @@ EOT;
       'bank_account_type' => "",
       'bank_account_no' => "",
       'bank_account_name' => "",
+      'entry_date' => null,
+      'unsubscribe_date' => null,
+      'status' => '',
     ];
-    $update_form = ['status' => 'regular'];
+    $update_form = [];
     foreach($update_field as $key => $val){
       if(isset($form[$key])){
         $update_form[$key] = $form[$key];

--- a/app/Models/Teacher.php
+++ b/app/Models/Teacher.php
@@ -135,7 +135,7 @@ EOT;
 
     //希望シフト
     $lesson_weeks = config('attribute.lesson_week');
-    $fields = ["lesson", "work", "trial"];
+    $fields = ["lesson","work", "trial", "season_lesson"];
     foreach($fields as $field){
       $is_setting_find = false;
       $tag_names = [];
@@ -159,7 +159,7 @@ EOT;
         }
       }
     }
-    $tag_names = ['lesson', 'kids_lesson', 'english_talk_lesson', 'teacher_character', 'manager_type'];
+    $tag_names = ['lesson', "lesson_place", 'kids_lesson', 'english_talk_lesson', 'teacher_character', 'manager_type'];
     foreach($tag_names as $tag_name){
       if(isset($form[$tag_name]) && count($form[$tag_name])>0){
         //設定があれば差し替え

--- a/database/migrations/2020_11_21_131216_add_entry_date_teachers.php
+++ b/database/migrations/2020_11_21_131216_add_entry_date_teachers.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddEntryDateTeachers extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::connection('mysql_common')->table('teachers', function (Blueprint $table) {
+          $table->date('entry_date')->nullable(true)->before('recess_start_date')->comment('入社日');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::connection('mysql_common')->table('teachers', function (Blueprint $table) {
+          $table->dropColumn('entry_date');
+        });
+    }
+}

--- a/database/migrations/2020_11_21_131604_add_entry_date_managers.php
+++ b/database/migrations/2020_11_21_131604_add_entry_date_managers.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddEntryDateManagers extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('managers', function (Blueprint $table) {
+            //
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('managers', function (Blueprint $table) {
+            //
+        });
+    }
+}

--- a/database/migrations/2020_11_21_133340_add_entry_date_students.php
+++ b/database/migrations/2020_11_21_133340_add_entry_date_students.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddEntryDateStudents extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::connection('mysql_common')->table('students', function (Blueprint $table) {
+          $table->date('entry_date')->nullable(true)->before('recess_start_date')->comment('入会日');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::connection('mysql_common')->table('students', function (Blueprint $table) {
+          $table->dropColumn('entry_date');
+        });
+    }
+}

--- a/public/js/base/base.js
+++ b/public/js/base/base.js
@@ -511,7 +511,11 @@
 				$("#"+form_id).on('hide.bs.modal', function () {
 					console.log('modal close');
 					if(front.isInput(form_id)==true){
-						return confirm("このフォームを閉じますか？\n入力したデータは残りません。");
+						if(confirm("このフォームを閉じますか？\n入力したデータは残りません。")){
+							$('.modal-body').scrollTop(0);
+							return true;
+						}
+						return false;
 					}
 				});
 				$("#"+form_id).on('hidden.bs.modal', function () {

--- a/resources/lang/en/labels.php
+++ b/resources/lang/en/labels.php
@@ -283,6 +283,8 @@ return [
   'charge_student' => 'Charge Student',
   'charge_teacher' => 'Charge Teacher',
   'recess_or_unsubscribe' => 'Recess Or Unsubscribe',
+  'join' => 'Join',
+  'entiring' => 'Entireing',
   'unsubscribe' => 'Unsubscribe',
   'retirement' => 'Retirement',
   'recess' => 'Recess',

--- a/resources/lang/en/labels.php
+++ b/resources/lang/en/labels.php
@@ -126,6 +126,7 @@ return [
   'charge_lesson' => 'Charge Lesson',
   'lesson_week_time' => 'time/week for lesson',
   'trial_week_time' => 'time/week for trial lesson',
+  'season_lesson_week_time' => 'time/week for season lesson',
   'week_day' => 'WeekDay',
   'charge_subject' => 'Charge Subject',
   'no_data' => 'No Data',
@@ -396,9 +397,9 @@ return [
   'ask_teacher_change_description' => 'About teacher change you should check',
   'teacher_change' => 'Change assigned teacher',
   'dummy_release' => 'Dummy Release',
-  'task_title' => 'ex: English_selfIntroduction',
-  'entry_milestone' => 'Special Importance',
   'text_materials' => 'Text Material',
+  'entry_milestone' => 'Special Importance',
   'menu' => 'Menu',
-
+  'task_title' => 'ex: English_selfIntroduction',
+  'workable_classroom' => 'Workable ClassRoom',
 ];

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -158,4 +158,5 @@ return [
  'info_mail_reply' => 'You cannot reply to this email address',
  'confirm_dummy_release' => 'Do you want to release the dummy status?',
  'mail_reply_recomend' => "＊This e-mail is for sending only, so we cannot reply to you. \n＊If you want to reply, you should use SaKuRa One Net.",
+ 'info_season_lesson_week_time' => "Season Lesson and Weekend Lesson, we will check the dates and times when you can work separately.\nAt that time, we will contact you as if you can work on the days and hours set above.",
  ];

--- a/resources/lang/ja/labels.php
+++ b/resources/lang/ja/labels.php
@@ -126,6 +126,7 @@ return [
   'charge_lesson' => '担当可能なレッスン',
   'lesson_week_time' => '担当可能な曜日・時間帯',
   'trial_week_time' => '体験授業可能な曜日・時間帯',
+  'season_lesson_week_time' => '季節講習・土日講習担当可能な曜日・時間帯',
   'week_day' => '曜日',
   'charge_subject' => '担当科目',
   'no_data' => 'データがありません',
@@ -400,5 +401,5 @@ return [
   'entry_milestone' => '特に重視してやってほしいこと',
   'menu' => 'メニュー',
   'task_title' => '例：算数_分数の足し算',
-
+  'workable_classroom' => '勤務可能な教室',
 ];

--- a/resources/lang/ja/labels.php
+++ b/resources/lang/ja/labels.php
@@ -283,6 +283,8 @@ return [
   'charge_student' => '担当生徒',
   'charge_teacher' => '担当講師',
   'recess_or_unsubscribe' => '休会・退会',
+  'join' => '入会',
+  'entiring' => '入社',
   'retirement' => '退職',
   'unsubscribe' => '退会',
   'recess' => '休会',

--- a/resources/lang/ja/messages.php
+++ b/resources/lang/ja/messages.php
@@ -158,4 +158,5 @@ return [
   'info_mail_reply' => 'このメールアドレスへの返信はできません',
   'confirm_dummy_release' => 'ダミーステータスを解除しますか？',
   'mail_reply_recomend' => "＊本メールは送信専用ですので、ご返信できません。\n＊ご返信は、SaKuRa One Netのメッセージ一覧をご利用ください。",
+  "info_season_lesson_week_time" => "春期・夏期・冬期の講習、土日講習については、別途勤務可能な日時の確認を行います。\nその際、上記の設定の曜日・時間帯は勤務可能として連絡を行います。",
 ];

--- a/resources/views/asks/ask_create.blade.php
+++ b/resources/views/asks/ask_create.blade.php
@@ -126,7 +126,7 @@ $(function(){
   $('.carousel-item .btn-next').on('click', function(e){
     var form_data = front.getFormValue('ask_entry');
     if(front.validateFormValue('ask_entry .carousel-item.active')){
-      $('body, html').scrollTop(0);
+      $('body, html, .modal-body').scrollTop(0);
       $('#ask_entry').carousel('next');
       $('#ask_entry').carousel({ interval : false});
       $("ol.step li").removeClass("is-current");
@@ -142,7 +142,7 @@ $(function(){
   });
   //戻る
   $('.carousel-item .btn-prev').on('click', function(e){
-    $('body, html').scrollTop(0);
+    $('body, html, .modal-body').scrollTop(0);
     $('#ask_entry').carousel('prev');
     $('#ask_entry').carousel({ interval : false});
   });

--- a/resources/views/calendar_settings/create.blade.php
+++ b/resources/views/calendar_settings/create.blade.php
@@ -118,7 +118,7 @@ $(function(){
   $('.carousel-item .btn-next').on('click', function(e){
     var form_data = front.getFormValue('calendar_settings_entry');
     if(front.validateFormValue('calendar_settings_entry .carousel-item.active')){
-      $('body, html').scrollTop(0);
+      $('body, html, .modal-body').scrollTop(0);
       $('#calendar_settings_entry').carousel('next');
       $('#calendar_settings_entry').carousel({ interval : false});
     }
@@ -134,7 +134,7 @@ $(function(){
   });
   //戻る
   $('.carousel-item .btn-prev').on('click', function(e){
-    $('body, html').scrollTop(0);
+    $('body, html, .modal-body').scrollTop(0);
     $('#calendar_settings_entry').carousel('prev');
     $('#calendar_settings_entry').carousel({ interval : false});
   });

--- a/resources/views/calendars/create.blade.php
+++ b/resources/views/calendars/create.blade.php
@@ -95,7 +95,7 @@ $(function(){
 
   //次へ
   $('.carousel-item .btn-next').on('click', function(e){
-
+    $('body, html, .modal-body').scrollTop(0);
     if($(this).hasClass('btn-confirm')){
       @if($item['exchanged_calendar_id'] > 0)
       if($("input[name='course_minutes']").length > 0 ){
@@ -106,7 +106,7 @@ $(function(){
 
     var form_data = front.getFormValue('calendars_entry');
     if(front.validateFormValue('calendars_entry .carousel-item.active')){
-      $('body, html').scrollTop(0);
+      $('body, html, .modal-body').scrollTop(0);
       $('#calendars_entry').carousel('next');
       $('#calendars_entry').carousel({ interval : false});
     }
@@ -122,7 +122,7 @@ $(function(){
   });
   //戻る
   $('.carousel-item .btn-prev').on('click', function(e){
-    $('body, html').scrollTop(0);
+    $('body, html, .modal-body').scrollTop(0);
     $('#calendars_entry').carousel('prev');
     $('#calendars_entry').carousel({ interval : false});
   });

--- a/resources/views/layouts/end.blade.php
+++ b/resources/views/layouts/end.blade.php
@@ -84,7 +84,7 @@ function status_style(status){
 <script src="{{asset('js/base/dom.js?v=2')}}"></script>
 <script src="{{asset('js/base/service.js?v=5')}}"></script>
 <script src="{{asset('js/base/front.js')}}"></script>
-<script src="{{asset('js/base/base.js?v=10')}}"></script>
+<script src="{{asset('js/base/base.js?v=11')}}"></script>
 <script src="{{asset('js/common.js?v=8')}}"></script>
 </body>
 

--- a/resources/views/managers/create_form.blade.php
+++ b/resources/views/managers/create_form.blade.php
@@ -55,3 +55,34 @@
   @component('students.forms.work_time', ['_edit'=>$_edit, 'item' =>$item->user, 'prefix'=>'work', 'attributes' => $attributes, 'title' => '勤務可能な曜日・時間帯']) @endcomponent
 </div>
 @endsection
+
+@section('account_date_form')
+<div class="col-6">
+  <label for="start_date" class="w-100">
+    {{__('labels.entiring')}}{{__('labels.day')}}
+    <span class="right badge badge-secondary ml-1">{{__('labels.optional')}}</span>
+  </label>
+  <div class="input-group">
+    <input type="text" name="entry_date" class="form-control float-left w-30" uitype="datepicker" placeholder="例：2000/01/01"
+    @if(isset($item) && !empty($item->entry_date))
+    value = "{{date('Y/m/d', strtotime($item->entry_date))}}"
+    @endif
+    >
+  </div>
+</div>
+@if($item->status=='unsubscribe')
+<div class="col-6">
+  <label for="start_date" class="w-100">
+    {{__('labels.unsubscribe')}}{{__('labels.day')}}
+    <span class="right badge badge-secondary ml-1">{{__('labels.optional')}}</span>
+  </label>
+  <div class="input-group">
+    <input type="text" name="unsubscribe_date" class="form-control float-left w-30" uitype="datepicker" placeholder="例：2000/01/01"
+    @if(isset($item) && !empty($item->unsubscribe_date))
+    value = "{{date('Y/m/d', strtotime($item->unsubscribe_date))}}"
+    @endif
+    >
+  </div>
+</div>
+@endif
+@endsection

--- a/resources/views/managers/page.blade.php
+++ b/resources/views/managers/page.blade.php
@@ -14,6 +14,9 @@
           @endslot
           @slot('alias')
           <h6 class="widget-user-desc">
+            <small class="badge badge-{{config('status_style')[$item->status]}} mt-1 mr-1">
+              {{$item->status_name()}}
+            </small>
             @foreach($item->user->tags as $tag)
               @if($tag->tag_key=="manager_no")
                 <small class="badge badge-dark mt-1 mr-1">

--- a/resources/views/managers/register.blade.php
+++ b/resources/views/managers/register.blade.php
@@ -136,7 +136,7 @@ $(function(){
   //次へ
   $('#managers_register .carousel-item .btn-next').on('click', function(e){
     if(front.validateFormValue('managers_register .carousel-item.active')){
-      $('body, html').scrollTop(0);
+      $('body, html, .modal-body').scrollTop(0);
       var form_data = front.getFormValue('managers_register');
       $('#managers_register').carousel('next');
       $('#managers_register').carousel({ interval : false});
@@ -144,7 +144,7 @@ $(function(){
   });
   //戻る
   $('#managers_register .carousel-item .btn-prev').on('click', function(e){
-    $('body, html').scrollTop(0);
+    $('body, html, .modal-body').scrollTop(0);
     $('#managers_register').carousel('prev');
     $('#managers_register').carousel({ interval : false});
   });

--- a/resources/views/students/forms/lesson_place.blade.php
+++ b/resources/views/students/forms/lesson_place.blade.php
@@ -1,7 +1,11 @@
 <div class="col-12 mt-2">
   <div class="form-group">
     <label for="lesson_place" class="w-100">
+      @if(!isset($title) || empty($title))
       ご希望の校舎
+      @else
+      {{$title}}
+      @endif
       <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
     </label>
     @foreach($attributes['places'] as $place)

--- a/resources/views/students/forms/work_time.blade.php
+++ b/resources/views/students/forms/work_time.blade.php
@@ -1,10 +1,10 @@
 <div class="col-12">
   <div class="form-group">
-    <label for="week_table" class="w-100">
+    <label for="{{$prefix}}week_table" class="w-100">
       {{$title}}
       <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
     </label>
-    <table class="table" id="week_table">
+    <table class="table" id="{{$prefix}}week_table">
     <tr class="bg-gray">
       <th class="p-1 text-center">時間帯 / 曜日</th>
       @foreach($attributes['lesson_week'] as $index => $name)
@@ -39,7 +39,7 @@
       </th>
       @foreach($attributes['lesson_week'] as $week_code => $week_name)
       <td class="p-1 text-center">
-        <input type="checkbox" value="{{ $index }}" name="{{$prefix}}_{{$week_code}}_time[]" class="icheck flat-green week_time" onChange="week_change(this)"  validate="week_validate()"
+        <input type="checkbox" value="{{ $index }}" name="{{$prefix}}_{{$week_code}}_time[]" class="icheck flat-green {{$prefix}}week_time"  validate="week_validate('{{$prefix}}')"
         @if($_edit===true && isset($item) && $item->has_tag($prefix.'_'.$week_code.'_time', $index)==1)
        checked
        @elseif($_edit==false)
@@ -56,39 +56,11 @@
     @endforeach
     </table>
     <script>
-    function week_change(obj){
-      return true;
-      //TODO disableのチェック処理を外す
-      var _name = $(obj).attr("name");
-      var _val = $(obj).val();
-      var _checked = $(obj).prop("checked");
-      console.log('week_change');
-      if(_checked && _val=='disabled'){
-        //個別時間帯をすべてdisabled
-        $('input[type="checkbox"][name="'+_name+'"][value!="disabled"]').each(function(i, e){
-          if($(e).attr("value") !== "disabled") {
-            $(this).prop('disabled', true);
-            $(this).iCheck('uncheck');
-            $(this).iCheck('disable');
-          }
-        });
-      }
-      else if(!_checked && _val=='disabled'){
-        $('input[type="checkbox"][name="'+_name+'"][value!="disabled"]').each(function(i, e){
-          if($(e).attr("value") !== "disabled"){
-            $(this).parent().removeClass('disabled');
-            $(this).prop('disabled', false);
-            $(this).iCheck('check');
-            $(this).iCheck('enable');
-          }
-        });
-      }
-    }
-    function week_validate(){
+    function week_validate(prefix){
       var _is_scceuss = false;
-      if( $("input.week_time[type='checkbox']").length > 0){
+      if( $("input."+prefix+"week_time[type='checkbox']").length > 0){
         var _week_input = [];
-        $("input.week_time[type='checkbox']").each(function(index, value){
+        $("input."+prefix+"week_time[type='checkbox']").each(function(index, value){
           var val = $(this).val();
           var name = $(this).attr('name');
           var checked = $(this).prop('checked');
@@ -98,14 +70,14 @@
             _week_input[name] = true;
           }
         });
-        console.log(_week_input[name]);
+        console.log(prefix+":"+_week_input[name]);
         for(var key in _week_input){
           if(_week_input[key] == false){
-            $("input.week_time[name='"+key+"'][value='disabled']").prop('checked', true);
+            $("input."+prefix+"week_time[name='"+key+"'][value='disabled']").prop('checked', true);
           }
         }
         if(!_is_scceuss){
-          front.showValidateError('#week_table', '希望の時間帯を１つ以上選択してください');
+          front.showValidateError('#'+prefix+'week_table', '希望の時間帯を１つ以上選択してください');
         }
       }
       else {

--- a/resources/views/students/forms/work_time.blade.php
+++ b/resources/views/students/forms/work_time.blade.php
@@ -23,8 +23,16 @@
       if($prefix=='trial' || $prefix=='season_lesson'){
         $attribute_name = 'lesson_time';
       }
+      $display = true;
+      if(isset($from_time_index)) $display = false;
     ?>
     @foreach($attributes[$attribute_name] as $index => $name)
+    <?php
+      if(isset($from_time_index) && $display==false && $index==$from_time_index){
+        $display = true;
+      }
+    ?>
+    @if($display!=true) @continue @endif
     <tr class="">
       <th class="p-1 text-center bg-gray text-sm week_time_label">
         {{$name}}
@@ -40,6 +48,11 @@
       </td>
       @endforeach
     </tr>
+    <?php
+      if(isset($to_time_index) && $display==true && $index==$to_time_index){
+        $display = false;
+      }
+    ?>
     @endforeach
     </table>
     <script>

--- a/resources/views/students/forms/work_time.blade.php
+++ b/resources/views/students/forms/work_time.blade.php
@@ -20,7 +20,7 @@
     </tr>
     <?php
       $attribute_name = $prefix.'_time';
-      if($prefix=='trial'){
+      if($prefix=='trial' || $prefix=='season_lesson'){
         $attribute_name = 'lesson_time';
       }
     ?>

--- a/resources/views/teachers/add_charge_student.blade.php
+++ b/resources/views/teachers/add_charge_student.blade.php
@@ -68,7 +68,7 @@ $(function(){
 
     var form_data = front.getFormValue('add_charge_student');
     if(front.validateFormValue('add_charge_student .carousel-item.active')){
-      $('body, html').scrollTop(0);
+      $('body, html, .modal-body').scrollTop(0);
       $('#add_charge_student').carousel('next');
       $('#add_charge_student').carousel({ interval : false});
     }
@@ -84,7 +84,7 @@ $(function(){
   });
   //戻る
   $('.carousel-item .btn-prev').on('click', function(e){
-    $('body, html').scrollTop(0);
+    $('body, html, .modal-body').scrollTop(0);
     $('#add_charge_student').carousel('prev');
     $('#add_charge_student').carousel({ interval : false});
   });

--- a/resources/views/teachers/create_form.blade.php
+++ b/resources/views/teachers/create_form.blade.php
@@ -11,8 +11,6 @@
 </div>
 @endsection
 
-
-
 @section('item_form')
 <div class="row">
   <div class="col-12">
@@ -70,11 +68,6 @@
 </div>
 @endsection
 
-@section('season_lesson_week_form')
-<div class="row">
-</div>
-@endsection
-
 
 @section('subject_form')
 <div class="row">
@@ -94,4 +87,35 @@
 <div class="row">
   @component('teachers.forms.teacher_character', ['_edit'=>$_edit, 'item'=>$item,'attributes' => $attributes]) @endcomponent
 </div>
+@endsection
+
+@section('account_date_form')
+<div class="col-6">
+  <label for="start_date" class="w-100">
+    {{__('labels.entiring')}}{{__('labels.day')}}
+    <span class="right badge badge-secondary ml-1">{{__('labels.optional')}}</span>
+  </label>
+  <div class="input-group">
+    <input type="text" name="entry_date" class="form-control float-left w-30" uitype="datepicker" placeholder="例：2000/01/01"
+    @if(isset($item) && !empty($item->entry_date))
+    value = "{{date('Y/m/d', strtotime($item->entry_date))}}"
+    @endif
+    >
+  </div>
+</div>
+@if($item->status=='unsubscribe')
+<div class="col-6">
+  <label for="start_date" class="w-100">
+    {{__('labels.unsubscribe')}}{{__('labels.day')}}
+    <span class="right badge badge-secondary ml-1">{{__('labels.optional')}}</span>
+  </label>
+  <div class="input-group">
+    <input type="text" name="unsubscribe_date" class="form-control float-left w-30" uitype="datepicker" placeholder="例：2000/01/01"
+    @if(isset($item) && !empty($item->unsubscribe_date))
+    value = "{{date('Y/m/d', strtotime($item->unsubscribe_date))}}"
+    @endif
+    >
+  </div>
+</div>
+@endif
 @endsection

--- a/resources/views/teachers/create_form.blade.php
+++ b/resources/views/teachers/create_form.blade.php
@@ -36,9 +36,15 @@
 </div>
 @endsection
 
-@section('lesson_week_form')
+@section('charge_form')
 <div class="row">
   @component('students.forms.lesson', ['_edit'=>$_edit, 'item'=>$item->user, 'attributes' => $attributes, 'prefix'=>'', 'title'=> __('labels.charge_lesson')]) @endcomponent
+  @component('students.forms.lesson_place', ['title'=>__('labels.workable_classroom'), '_edit'=>$_edit, 'item'=>$item->user, 'attributes' => $attributes]) @endcomponent
+</div>
+@endsection
+
+@section('lesson_week_form')
+<div class="row">
   @component('students.forms.work_time', ['_edit'=>$_edit, 'item'=>$item->user, 'prefix'=> 'lesson', 'attributes' => $attributes, 'title' => __('labels.lesson_week_time')]) @endcomponent
   @component('students.forms.work_time', ['_edit'=>$_edit, 'item'=>$item->user, 'prefix'=> 'trial', 'attributes' => $attributes, 'title' => __('labels.trial_week_time')]) @endcomponent
   <div class="col-12">
@@ -52,6 +58,13 @@
   </div>
 </div>
 @endsection
+
+@section('season_lesson_week_form')
+<div class="row">
+  @component('students.forms.work_time', ['_edit'=>$_edit, 'item'=>$item->user, 'prefix'=> 'season_lesson', 'attributes' => $attributes, 'title' => __('labels.lesson_week_time')]) @endcomponent
+</div>
+@endsection
+
 
 @section('subject_form')
 <div class="row">

--- a/resources/views/teachers/create_form.blade.php
+++ b/resources/views/teachers/create_form.blade.php
@@ -40,13 +40,9 @@
 <div class="row">
   @component('students.forms.lesson', ['_edit'=>$_edit, 'item'=>$item->user, 'attributes' => $attributes, 'prefix'=>'', 'title'=> __('labels.charge_lesson')]) @endcomponent
   @component('students.forms.lesson_place', ['title'=>__('labels.workable_classroom'), '_edit'=>$_edit, 'item'=>$item->user, 'attributes' => $attributes]) @endcomponent
-</div>
-@endsection
-
-@section('lesson_week_form')
-<div class="row">
   @component('students.forms.work_time', ['_edit'=>$_edit, 'item'=>$item->user, 'prefix'=> 'lesson', 'attributes' => $attributes, 'title' => __('labels.lesson_week_time')]) @endcomponent
-  @component('students.forms.work_time', ['_edit'=>$_edit, 'item'=>$item->user, 'prefix'=> 'trial', 'attributes' => $attributes, 'title' => __('labels.trial_week_time')]) @endcomponent
+</div>
+<div class="row">
   <div class="col-12">
     <div class="form-group">
       <label for="schedule_remark" class="w-100">
@@ -59,9 +55,23 @@
 </div>
 @endsection
 
+@section('lesson_week_form')
+<div class="row">
+  @component('students.forms.work_time', ['_edit'=>$_edit, 'item'=>$item->user, 'prefix'=> 'trial', 'attributes' => $attributes, 'title' => __('labels.trial_week_time')]) @endcomponent
+</div>
+<div class="row subject_form">
+  @component('students.forms.work_time', ['_edit'=>$_edit, 'item'=>$item->user, 'prefix'=> 'season_lesson', 'attributes' => $attributes, 'title' => __('labels.season_lesson_week_time'), 'from_time_index' => '11_12', 'to_time_index'=> '17_18']) @endcomponent
+  <div class="col-12">
+    <div class="alert alert-warning text-sm">
+      <i class="icon fa fa-exclamation-triangle"></i>
+      {!!nl2br(__('messages.info_season_lesson_week_time'))!!}
+    </div>
+  </div>
+</div>
+@endsection
+
 @section('season_lesson_week_form')
 <div class="row">
-  @component('students.forms.work_time', ['_edit'=>$_edit, 'item'=>$item->user, 'prefix'=> 'season_lesson', 'attributes' => $attributes, 'title' => __('labels.lesson_week_time')]) @endcomponent
 </div>
 @endsection
 

--- a/resources/views/teachers/edit.blade.php
+++ b/resources/views/teachers/edit.blade.php
@@ -5,11 +5,14 @@
     @csrf
     <input type="text" name="dummy" style="display:none;" / >
     @yield('item_form')
-    @if($user->role=="manager")
-    @component('students.forms.editable_email', ['item' =>$item, 'attributes' => $attributes, 'is_label'=>true]) @endcomponent
-    @else
-    @component('students.forms.email', ['item'=>$item, 'attributes' => $attributes, 'is_label'=>true]) @endcomponent
-    @endif
+    <div class="row mb-2">
+      @if($user->role=="manager")
+      @component('students.forms.editable_email', ['item' =>$item, 'attributes' => $attributes, 'is_label'=>true]) @endcomponent
+      @yield('account_date_form')
+      @else
+        @component('students.forms.email', ['item'=>$item, 'attributes' => $attributes, 'is_label'=>true]) @endcomponent
+      @endif
+    </div>
     @yield('bank_form')
     <div class="row">
       <div class="col-12 mb-1">

--- a/resources/views/teachers/page.blade.php
+++ b/resources/views/teachers/page.blade.php
@@ -13,6 +13,9 @@
           @endslot
           @slot('alias')
             <h6 class="widget-user-desc">
+              <small class="badge badge-{{config('status_style')[$item->status]}} mt-1 mr-1">
+                {{$item->status_name()}}
+              </small>
               @foreach($item->user->tags as $tag)
                 @if($tag->tag_key=="teacher_no")
                   <small class="badge badge-dark mt-1 mr-1">

--- a/resources/views/teachers/page/setting_menu.blade.php
+++ b/resources/views/teachers/page/setting_menu.blade.php
@@ -20,7 +20,7 @@
     </a>
   </div>
   <div class="col-12 col-lg-4 col-md-6 mb-1">
-    <a class="" href="javascript:void(0);" page_form="dialog" page_url="/{{$domain}}/{{$item->id}}/edit" page_title="{{__('labels.working')}}{{__('labels.setting')}}">
+    <a class="" href="javascript:void(0);" page_form="dialog" page_url="/{{$domain}}/{{$item->id}}/edit" page_title="{{__('labels.teacher_setting')}}">
     <div class="info-box">
       <span class="info-box-icon bg-secondary">
         <i class="fa fa-user-edit"></i>

--- a/resources/views/teachers/register.blade.php
+++ b/resources/views/teachers/register.blade.php
@@ -152,7 +152,7 @@ $(function(){
   $('.carousel-item .btn-next').on('click', function(e){
     if(front.validateFormValue('teachers_register .carousel-item.active')){
       var form_data = front.getFormValue('teachers_register');
-      $('body, html').scrollTop(0);
+      $('body, html, .modal-body').scrollTop(0);
       $('#teachers_register').carousel('next');
       $('#teachers_register').carousel({ interval : false});
 
@@ -160,7 +160,7 @@ $(function(){
   });
   //戻る
   $('.carousel-item .btn-prev').on('click', function(e){
-    $('body, html').scrollTop(0);
+    $('body, html, .modal-body').scrollTop(0);
     $('#teachers_register').carousel('prev');
     $('#teachers_register').carousel({ interval : false});
   });

--- a/resources/views/teachers/register.blade.php
+++ b/resources/views/teachers/register.blade.php
@@ -65,6 +65,7 @@
     <div id="teachers_register" class="carousel slide" data-ride="carousel" data-interval="false">
       <input type="hidden" name="access_key" value="{{$access_key}}" />
       <input type="hidden" name="id" value="{{$item->id}}" />
+      <input type="hidden" name="status" value="regular" />
       <div class="carousel-inner">
         <div class="carousel-item active">
           @yield('item_form')
@@ -80,6 +81,23 @@
         <div class="carousel-item">
           @yield('account_form')
           @yield('bank_form')
+          <div class="row">
+            <div class="col-12 mb-1">
+              <a href="javascript:void(0);" role="button" class="btn-prev btn btn-secondary btn-block float-left mr-1">
+                <i class="fa fa-arrow-circle-left mr-1"></i>
+                {{__('labels.back_button')}}
+              </a>
+            </div>
+            <div class="col-12 mb-1">
+              <a href="javascript:void(0);" role="button" class="btn-next btn btn-primary btn-block float-left mr-1">
+                <i class="fa fa-arrow-circle-right mr-1"></i>
+                {{__('labels.next_button')}}
+              </a>
+            </div>
+          </div>
+        </div>
+        <div class="carousel-item">
+          @yield('charge_form')
           <div class="row">
             <div class="col-12 mb-1">
               <a href="javascript:void(0);" role="button" class="btn-prev btn btn-secondary btn-block float-left mr-1">

--- a/resources/views/teachers/setting.blade.php
+++ b/resources/views/teachers/setting.blade.php
@@ -84,6 +84,7 @@ $(function(){
 
   //次へ
   $('.carousel-item .btn-next').on('click', function(e){
+    $('body, html, .modal-body').scrollTop(0);
     if(front.validateFormValue('teachers_edit .carousel-item.active')){
       var form_data = front.getFormValue('teachers_edit');
       $('#teachers_edit').carousel('next');
@@ -92,6 +93,7 @@ $(function(){
   });
   //戻る
   $('.carousel-item .btn-prev').on('click', function(e){
+    $('body, html, .modal-body').scrollTop(0);
     $('#teachers_edit').carousel('prev');
     $('#teachers_edit').carousel({ interval : false});
   });

--- a/resources/views/teachers/setting.blade.php
+++ b/resources/views/teachers/setting.blade.php
@@ -6,46 +6,63 @@
     @method('PUT')
     <div class="carousel slide" data-ride="carousel" data-interval="false">
       <div class="carousel-inner">
-        <div class="carousel-item active">
-          @yield('lesson_week_form')
-          <div class="row">
-            <div class="col-12 mb-1">
-              <a href="javascript:void(0);" data-dismiss="modal" role="button" class="btn btn-secondary btn-block float-left mr-1">
-                <i class="fa fa-times-circle mr-1"></i>
-                {{__('labels.cancel_button')}}
-              </a>
-            </div>
-            <div class="col-12 mb-1">
-              <a href="javascript:void(0);" role="button" class="btn-next btn btn-primary btn-block float-left mr-1">
-                <i class="fa fa-arrow-circle-right mr-1"></i>
-                {{__('labels.next_button')}}
-              </a>
-            </div>
-          </div>
-        </div>
-        <div class="carousel-item">
-          @yield('subject_form')
-          <div class="row">
-            <div class="col-12 mb-1">
-              <a href="javascript:void(0);" role="button" class="btn-prev btn btn-secondary btn-block float-left mr-1">
-                <i class="fa fa-arrow-circle-left mr-1"></i>
-                {{__('labels.back_button')}}
-              </a>
-            </div>
-            <div class="col-12 mb-1">
-              <a href="javascript:void(0);" data-dismiss="modal" role="button" class="btn btn-secondary btn-block float-left mr-1">
-                <i class="fa fa-times-circle mr-1"></i>
-                {{__('labels.cancel_button')}}
-              </a>
-            </div>
-            <div class="col-12 mb-1">
-                <button type="button" class="btn btn-submit btn-primary btn-block" accesskey="teachers_edit">
-                  <i class="fa fa-edit mr-1"></i>
-                  {{__('labels.update_button')}}
-                </button>
+          <div class="carousel-item active">
+            @yield('charge_form')
+            <div class="row">
+              <div class="col-12 mb-1">
+                <a href="javascript:void(0);" data-dismiss="modal" role="button" class="btn btn-secondary btn-block float-left mr-1">
+                  <i class="fa fa-times-circle mr-1"></i>
+                  {{__('labels.cancel_button')}}
+                </a>
+              </div>
+              <div class="col-12 mb-1">
+                <a href="javascript:void(0);" role="button" class="btn-next btn btn-primary btn-block float-left mr-1">
+                  <i class="fa fa-arrow-circle-right mr-1"></i>
+                  {{__('labels.next_button')}}
+                </a>
+              </div>
             </div>
           </div>
-        </div>
+          <div class="carousel-item">
+            @yield('lesson_week_form')
+            <div class="row">
+              <div class="col-12 mb-1">
+                <a href="javascript:void(0);" role="button" class="btn-prev btn btn-secondary btn-block float-left mr-1">
+                  <i class="fa fa-arrow-circle-left mr-1"></i>
+                  {{__('labels.back_button')}}
+                </a>
+              </div>
+              <div class="col-12 mb-1">
+                <a href="javascript:void(0);" role="button" class="btn-next btn btn-primary btn-block float-left mr-1">
+                  <i class="fa fa-arrow-circle-right mr-1"></i>
+                  {{__('labels.next_button')}}
+                </a>
+              </div>
+            </div>
+          </div>
+          <div class="carousel-item">
+            @yield('subject_form')
+            <div class="row">
+              <div class="col-12 mb-1">
+                <a href="javascript:void(0);" role="button" class="btn-prev btn btn-secondary btn-block float-left mr-1">
+                  <i class="fa fa-arrow-circle-left mr-1"></i>
+                  {{__('labels.back_button')}}
+                </a>
+              </div>
+              <div class="col-12 mb-1">
+                <a href="javascript:void(0);" data-dismiss="modal" role="button" class="btn btn-secondary btn-block float-left mr-1">
+                  <i class="fa fa-times-circle mr-1"></i>
+                  {{__('labels.cancel_button')}}
+                </a>
+              </div>
+              <div class="col-12 mb-1">
+                  <button type="button" class="btn btn-submit btn-primary btn-block" accesskey="teachers_edit">
+                    <i class="fa fa-edit mr-1"></i>
+                    {{__('labels.update_button')}}
+                  </button>
+              </div>
+            </div>
+          </div>
       </div>
     </div>
   </form>

--- a/resources/views/trials/confirm.blade.php
+++ b/resources/views/trials/confirm.blade.php
@@ -92,6 +92,7 @@ $(function(){
 
   //次へ
   $('.carousel-item .btn-next').on('click', function(e){
+    $('body, html, .modal-body').scrollTop(0);
     if(front.validateFormValue('trials_confirm .carousel-item.active')){
       var form_data = front.getFormValue('trials_confirm');
       util.setLocalData('trials_confirm', form_data);
@@ -102,6 +103,7 @@ $(function(){
   });
   //戻る
   $('.carousel-item .btn-prev').on('click', function(e){
+    $('body, html, .modal-body').scrollTop(0);
     $('#trials_confirm').carousel('prev');
     $('#trials_confirm').carousel({ interval : false});
   });

--- a/resources/views/trials/forms/entry_page_script.blade.php
+++ b/resources/views/trials/forms/entry_page_script.blade.php
@@ -27,12 +27,13 @@ $(function(){
 
   //次へ
   $('.carousel-item .btn-next').on('click', function(e){
+    $('body, html, .modal-body').scrollTop(0);
     var form_data = front.getFormValue('trials_entry');
     if(front.validateFormValue('trials_entry .carousel-item.active')){
       @if($_edit==false)
       util.setLocalData('trials_entry', form_data);
       @endif
-      $('body, html').scrollTop(0);
+      $('body, html, .modal-body').scrollTop(0);
       $('#trials_entry').carousel('next');
       $('#trials_entry').carousel({ interval : false});
     }
@@ -48,7 +49,7 @@ $(function(){
   });
   //戻る
   $('.carousel-item .btn-prev').on('click', function(e){
-    $('body, html').scrollTop(0);
+    $('body, html, .modal-body').scrollTop(0);
     $('#trials_entry').carousel('prev');
     $('#trials_entry').carousel({ interval : false});
   });


### PR DESCRIPTION
講師詳細＞勤務設定
・勤務希望教室
・季節講習、土日講習の勤務可能日を編集し保存可能となること

追記(レビュー内容更新）
①新規登録時にも対応
講師一覧＞登録依頼（新規講師）
新規登録時も、同様の勤務希望教室・季節講習・土日講習のフォーム追加

②講師詳細＞講師設定
事務管理者権限にて、入社日・退職日を入力できるように対応
（退職日は、ステータス＝退職の場合のみ表示される）

③モーダル表示で、スクロールされた状態が維持される
　→　されないように修正

④季節講習・土日講習・体験の可能日時設定が必須じゃない件
　→　必須になるようエラーチェック追加

⑤講師設定のモーダルのタイトルが、勤務設定になっていた
　→　講師設定にタイトル変更