### PR TITLE
休み判別でエラーした

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -202,7 +202,7 @@ class TaskController extends MilestoneController
         $param['subjects'] = Subject::all();
         $lessons = collect($param['target_student']->get_tags('lesson'));
         $param['lessons'] = $lessons;
-        $param['has_english_lesson'] = $lessons->pluck('value')->contains(2);
+        $param['has_english_lesson'] = $lessons->pluck('tag_value')->contains(2);
         return view($this->domain.'.create')->with($param);
     }
 

--- a/app/Models/UserCalendarMember.php
+++ b/app/Models/UserCalendarMember.php
@@ -338,15 +338,15 @@ class UserCalendarMember extends Model
     foreach($this->calendar->members as $_member){
       $user = $_member->user->details('students');
       if($user->role==="student"){
-        $student_no = $user->get_tag('student_no')["value"];
+        $student_no = $user->get_tag_value('student_no');
       }
       $user = $_member->user->details('teachers');
       if($user->role==="teacher"){
-        $teacher_no = $user->get_tag('teacher_no')["value"];
+        $teacher_no = $user->get_tag_value('teacher_no');
       }
       $user = $_member->user->details('managers');
       if($user->role==="manager" || $user->role==="staff"){
-        $manager_no = $user->get_tag('manager_no')["value"];
+        $manager_no = $user->get_tag_value('manager_no');
       }
     }
     \Log::warning("事務システムAPI student_no=:".$student_no."\nteacher_no=".$teacher_no);

--- a/app/Models/UserCalendarMemberSetting.php
+++ b/app/Models/UserCalendarMemberSetting.php
@@ -73,15 +73,15 @@ class UserCalendarMemberSetting extends UserCalendarMember
     foreach($this->setting->members as $_member){
       $user = $_member->user->details('students');
       if($user->role==="student"){
-        $student_no = $user->get_tag('student_no')["value"];
+        $student_no = $user->get_tag_value('student_no');
       }
       $user = $_member->user->details('teachers');
       if($user->role==="teacher"){
-        $teacher_no = $user->get_tag('teacher_no')["value"];
+        $teacher_no = $user->get_tag_value('teacher_no');
       }
       $user = $_member->user->details('managers');
       if($user->role==="manager"){
-        $manager_no = $user->get_tag('manager_no')["value"];
+        $manager_no = $user->get_tag_value('manager_no');
       }
     }
     \Log::warning("事務システムAPI student_no=:".$student_no."\nteacher_no=".$teacher_no."\nwork=".$this->setting->work);


### PR DESCRIPTION
原因として、
元々、ユーザータグを利用するロジックを共通化する際、
tag_value→valueとしていた箇所が、tag_valueになったことで値取得できなくなり、エラーとなった