### PR TITLE
休み連絡日の対応及び、休み判定が取れなかった場合のリカバリ

### DIFF
--- a/app/Models/UserCalendarMember.php
+++ b/app/Models/UserCalendarMember.php
@@ -152,6 +152,9 @@ class UserCalendarMember extends Model
         $is_send_mail = false;
         $is_send_teacher_mail = false;
         break;
+      case "rest":
+        if($this->rest_contact_date == null) $update_form['rest_contact_date'] = date('Y-m-d H:i:s');
+        break;
     }
 
     if($is_update==true){
@@ -718,5 +721,68 @@ class UserCalendarMember extends Model
     $item['str_exchange_limit_date'] = $this->dateweek_format($this->exchange_limit_date);
 
     return $this;
+  }
+  //Todo 休み判定（暫定版）
+  //本休み判定は、会計システムリプレース時にoffice_system_apiで対応している更新＋休み判定を置き換える
+  public function _rest_judgement(){
+    if($this->status != 'rest') return null;
+    if($this->user_id == $this->calendar->user_id) return null;
+    if($this->user->get_role() != 'student') return null;
+    //休み2当日の期限＝その予定の前日21時
+    $d = date('Y-m-d 21:00:00', strtotime("-1 day ".$this->calendar->start_time));
+    //振替期限
+    $exchange_limit_date = date('Y-m-d', strtotime("+2 month ".$this->calendar->start_time));
+    //休み２当日かどうかの判定
+    if(strtotime($this->rest_contact_date) > strtotime($d)){
+      //休み２当日
+      return ['rest_type'=>'a2', 'exchange_limit_date' => null, 'rest_result' => '当日', 'description' => $d.'<['.$this->rest_contact_date.']/a2'];
+    }
+    //規定回数かチェック
+    $lesson = $this->calendar->lesson(true);
+    $lesson_week_count = 0;
+    foreach($this->user->get_enable_lesson_calendar_settings() as $lesson=>$d1){
+      foreach($d1 as $method => $d2){
+        foreach($d2 as $week => $d3){
+          foreach($d3 as $i => $d4){
+            //休み判定は部門ごとで独立しているので、同じ部門の通塾設定がいくつあるか取得する
+            if($this->calendar->has_tag('lesson', $lesson) && $d4->is_group()==$this->calendar->is_group()){
+              $lesson_week_count++;
+            }
+          }
+        }
+      }
+    }
+    $from = date('Y-m-1', strtotime($this->calendar->start_time));
+    $to = date('Y-m-1', strtotime('+1 month '.$from));
+    //当月のカレンダーを、休み連絡順にソート
+    $monthly_rests = UserCalendarMember::where('user_id', $this->user_id)->where('status', 'rest')
+              ->whereHas('calendar', function($query) use ($from, $to){
+                $query->where('start_time', '>=', $from)
+                      ->where('start_time', '<', $to);
+              })->orderBy('rest_contact_date')->orderBy('created_at')->get();
+    $rest_count = 0;
+    foreach($monthly_rests as $monthly_rest){
+      if($monthly_rest->id == $this->id){
+        if($rest_count < $lesson_week_count){
+          //規定回数以内の休み
+          //Todo 休み判定（暫定版）
+          //斬作業として、ユーザーごとの休み判定タグを参照し、さらにロジックコントロールする部分が未実装
+          if($this->calendar->is_group()){
+            //グループレッスンの場合：a1 / 無償休み
+            return ['rest_type'=>'a1', 'exchange_limit_date' => null, 'rest_result' => '', 'description' => 'group('.$rest_count.'/'.$lesson_week_count.')/a1'];
+          }
+          else {
+            //マンツーマンの場合： a2 /  有償＋振替あり
+            return ['rest_type'=>'a2', 'exchange_limit_date' => $exchange_limit_date, 'rest_result' => '', 'description' => 'single('.$rest_count.'/'.$lesson_week_count.')/a2+ex'];
+          }
+        }
+        else {
+          //規定回数以上 / 有償＋振替なし
+          return ['rest_type'=>'a2', 'exchange_limit_date' => null, 'rest_result' => '規定回数以上', 'description' => '規定回数以上'];
+        }
+      }
+      $rest_count++;
+    }
+    return null;
   }
 }

--- a/database/migrations/2020_11_24_153059_add_rest_contact_date_user_calendar_members.php
+++ b/database/migrations/2020_11_24_153059_add_rest_contact_date_user_calendar_members.php
@@ -37,7 +37,7 @@ class AddRestContactDateUserCalendarMembers extends Migration
                       ->where('url', 'like', '%/calendars/'.$member->calendar_id.'')
                       ->where('url', 'not like', '%/status_update/%')
                       ->whereRaw('login_user_id in (select user_id from common.student_parents)',[])
-                      ->where('post_param', 'not like', '%_status":"rest"%')
+                      ->where('post_param', 'like', '%_status":"rest"%')
                       ->first();
             if(isset($log)){
               \Log::warning("is_group?:".$member->calendar->is_group());

--- a/database/migrations/2020_11_24_153059_add_rest_contact_date_user_calendar_members.php
+++ b/database/migrations/2020_11_24_153059_add_rest_contact_date_user_calendar_members.php
@@ -1,0 +1,63 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use App\Models\UserCalendarMember;
+use App\Models\ActionLog;
+
+class AddRestContactDateUserCalendarMembers extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('user_calendar_members', function (Blueprint $table) {
+          $table->timestamp('rest_contact_date')->nullable(true)->after('schedule_id')->comment('休み連絡日');
+        });
+
+        $members = UserCalendarMember::where('status', 'rest')->get();
+        foreach($members as $member){
+          $role = $member->user->get_role();
+          if($role!='student') continue;
+          $log = ActionLog::where('method', 'POST')
+                    ->where('url', 'like', '%/calendars/'.$member->calendar_id.'/status_update/rest')
+                    ->whereRaw('login_user_id in (select user_id from common.student_parents)',[])
+                    ->first();
+          $u = null;
+          if(isset($log)){
+            \Log::warning("is_single?:".$member->calendar->is_group());
+            $u = $log->created_at;
+          }
+          else {
+            $log = ActionLog::where('method', 'POST')
+                      ->where('url', 'like', '%/calendars/'.$member->calendar_id.'')
+                      ->where('url', 'not like', '%/status_update/%')
+                      ->whereRaw('login_user_id in (select user_id from common.student_parents)',[])
+                      ->where('post_param', 'not like', '%_status":"rest"%')
+                      ->first();
+            if(isset($log)){
+              \Log::warning("is_group?:".$member->calendar->is_group());
+              $u = $log->created_at;
+            }
+          }
+          if($u==null) continue;
+          $member->update(['rest_contact_date' => $u]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('user_calendar_members', function (Blueprint $table) {
+          $table->dropColumn('rest_contact_date');
+        });
+    }
+}

--- a/database/seeds/CalendarRecoverySeeder.php
+++ b/database/seeds/CalendarRecoverySeeder.php
@@ -252,6 +252,10 @@ EOT;
               continue;
         }
         $member->update(['rest_type' => $res['rest_type'],'rest_result' => $res['rest_result'],'exchange_limit_date' => $res['exchange_limit_date']]);
+        DB::table('hachiojisakura_calendar.tbl_schedule_onetime')->where('id', $member->schedule_id)->update([
+          'cancel' => $res['rest_type'],
+          'cancel_reason' => $res['rest_result'] 
+        ]);
       }
     }
 }

--- a/database/seeds/CalendarRecoverySeeder.php
+++ b/database/seeds/CalendarRecoverySeeder.php
@@ -17,10 +17,12 @@ class CalendarRecoverySeeder extends Seeder
     {
       set_time_limit(3600);
       $this->set_rest_judgement();
+
       $this->delete_calendar_sync();
       $this->post_calendar_sync();
       $this->put_calendar_sync();
       $this->season_schedule_lesson_sync();
+
     }
     public function delete_calendar_sync(){
       $this->no_relate_onetime_schedule_delete();
@@ -254,7 +256,7 @@ EOT;
         $member->update(['rest_type' => $res['rest_type'],'rest_result' => $res['rest_result'],'exchange_limit_date' => $res['exchange_limit_date']]);
         DB::table('hachiojisakura_calendar.tbl_schedule_onetime')->where('id', $member->schedule_id)->update([
           'cancel' => $res['rest_type'],
-          'cancel_reason' => $res['rest_result'] 
+          'cancel_reason' => $res['rest_result']
         ]);
       }
     }


### PR DESCRIPTION
①最新のdbをリストア
②php artisan migrate
　→　rest_contact_dateに値が入ること
③php artisan db:seed --class=CalendarRecoverySeeder
　→   休み判定が、onetime / user_calendar_membersに入ること


