### PR TITLE
休日マスタが更新されない→自動で更新するように対応

### DIFF
--- a/app/Console/Commands/CalendarSettingCommand.php
+++ b/app/Console/Commands/CalendarSettingCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Console\Command;
 use App\Models\UserCalendarSetting;
 use App\Models\UserCalendar;
+use App\Models\Holiday;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
 
@@ -48,6 +49,7 @@ class CalendarSettingCommand extends Command
       if(!empty($this->option("view_mode"))){
         $view_mode = true;
       }
+      Holiday::holiday_update(); //休日を更新しておく
       $this->to_calendar($this->option("start_date"), $this->option("end_date"), $this->option("range_month"), $this->option("week_count"), $this->option("id"), $view_mode);
     }
     public function to_calendar($start_date='', $end_date='', $range_month=1, $week_count=5, $id=0, $view_mode=false)

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -219,27 +219,6 @@ class Controller extends BaseController
        $this->send_slack("アップロードファイル削除:\n".$file, "info", "s3_delete");
        return $ret;
      }
-     //Googleカレンダーから祝日を取得
-     public function getHolidays() {
-       $url = "https://www8.cao.go.jp/chosei/shukujitsu/syukujitsu.csv";
-
-       //JSON形式で取得した情報を配列に変換
-       $results = file_get_contents($url);
-       $results = mb_convert_encoding($results, 'UTF-8', 'sjis-win');
-       $temp = tmpfile();
-       $csv  = array();
-
-       fwrite($temp, $results);
-       rewind($temp);
-
-       while (($results = fgetcsv($temp, 0, ",")) !== FALSE) {
-           $csv[] = $results;
-       }
-       fclose($temp);
-
-       //配列として祝日を返す
-       return $csv;
-     }
      public function transaction($request, $callback, $logic_name, $__file, $__function, $__line){
          try {
            DB::beginTransaction();

--- a/app/Models/Holiday.php
+++ b/app/Models/Holiday.php
@@ -41,4 +41,56 @@ class Holiday extends Model
     }
     return false;
   }
+  //Googleカレンダーから祝日を取得
+  static protected function holiday_update() {
+    $url = "https://www8.cao.go.jp/chosei/shukujitsu/syukujitsu.csv";
+
+    //JSON形式で取得した情報を配列に変換
+    $results = file_get_contents($url);
+    $results = mb_convert_encoding($results, 'UTF-8', 'sjis-win');
+    $temp = tmpfile();
+    $csv  = array();
+
+    fwrite($temp, $results);
+    rewind($temp);
+
+    while (($results = fgetcsv($temp, 0, ",")) !== FALSE) {
+        $csv[] = $results;
+    }
+    fclose($temp);
+    $i=0;
+    foreach($csv as $i => $d){
+      if($i==0) continue;
+      Holiday::add($d[0], $d[1], true, false);
+    }
+
+    //12-30～1-3までは休校日扱い
+    $private_holidays = ['12-30', '12-31', '1-1', '1-2', '1-3'];
+    $y = date('Y'); //今年,来年、再来年分ぐらいを登録しておく
+
+    for($i=$y;$i<$y+3;$i++){
+      foreach($private_holidays as $day){
+        $holiday = Holiday::add($i.'-'.$day, '休校日', false, true);
+        $holiday->update(['is_private_holiday' => 1]);
+      }
+    }
+  }
+
+  static protected function add($day, $remark, $is_public=false, $is_private=false){
+    $day = date('Y-m-d', strtotime($day));
+    if(strtotime($day) < strtotime('1999-01-01')) return null;
+    $holiday = Holiday::where('date', $day)->first();
+    if(!isset($holiday)){
+      //存在しない場合登録
+      $item = ['date' => $day, 'remark' => $remark];
+      if($is_public==true){
+        $item['is_public_holiday'] = 1;
+      }
+      if($is_private==true){
+        $item['is_private_holiday'] = 1;
+      }
+      $holiday = Holiday::create($item);
+    }
+    return $holiday;
+  }
 }

--- a/app/Models/Holiday.php
+++ b/app/Models/Holiday.php
@@ -41,7 +41,7 @@ class Holiday extends Model
     }
     return false;
   }
-  //Googleカレンダーから祝日を取得
+  //内閣府HPから祝日を取得
   static protected function holiday_update() {
     $url = "https://www8.cao.go.jp/chosei/shukujitsu/syukujitsu.csv";
 

--- a/database/seeds/HolidaySeeder.php
+++ b/database/seeds/HolidaySeeder.php
@@ -14,38 +14,7 @@ class HolidaySeeder extends Seeder
      */
     public function run()
     {
-      $controller = new Controller;
-      $res = $controller->getHolidays();
-      $controller->send_slack('国民の休日CSV取り込み', 'info');
-      foreach($res as $i => $d){
-        if($i==0) continue;
-        $this->add($d[0], $d[1], true, false);
-      }
-      $private_holidays = ['12-30', '12-31', '1-1', '1-2', '1-3'];
-      $y = date('Y');
-      foreach($private_holidays as $day){
-        $holiday = $this->add($y.'-'.$day, '休校日', false, true);
-      }
-      $y = $y+1;
-      foreach($private_holidays as $day){
-        $holiday = $this->add($y.'-'.$day, '休校日', false, true);
-        $holiday->update(['is_private_holiday' => 1]);
-      }
+      Holiday::holiday_update();
     }
-    private function add($day, $remark, $is_public=false, $is_private=false){
-      $day = date('Y-m-d', strtotime($day));
-      if(strtotime($day) < strtotime('1999-01-01')) return null;
-      $holiday = Holiday::where('date', $day)->first();
-      if(!isset($holiday)){
-        $item = ['date' => $day, 'remark' => $remark];
-        if($is_public==true){
-          $item['is_public_holiday'] = 1;
-        }
-        if($is_private==true){
-          $item['is_private_holiday'] = 1;
-        }
-        $holiday = Holiday::create($item);
-      }
-      return $holiday;
-    }
+
 }


### PR DESCRIPTION
①CalendarSettingCommand(繰り返し設定 To 予定の処理内で完結させる）
②Controller.php Googleカレンダーから公的な休み取ってくる処理を移設 to Modals/Holiday
③HolidaySeeder.php　休みセットするyそりを移設 to Models/Holiday

■確認方法
php artisan db:seed --class=HolidaySeeder
休日マスタの更新が走る（休校日については、3年分保存するようにした）

php artisan calendarsetting:make
繰り返し設定 To 予定の処理内で休日マスタの更新が走る

以上でーす