### PR TITLE
カレンダー・カレンダー設定のステータス検索条件に、ダミーを表示する

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -24,13 +24,15 @@ class UserController extends Controller
   }
   protected function attributes()
   {
+    $user = $this->login_details(new Request());
+
     $attributes = [];
     $_attributes = GeneralAttribute::where('attribute_key', '!=', 'keys')
     ->orderBy('attribute_key', 'asc')
     ->orderBy('sort_no', 'asc')->get();
     foreach($_attributes as $_attribute){
       //TODO いつかGeneralAttributeですべて管理しきるほがよいかもしれない（is_visible : 画面で使うもの / is_editable : 更新してもよいもの）
-      if($_attribute->attribute_value=='dummy') continue;
+      if($this->is_manager($user->role)!=true && $_attribute->attribute_value=='dummy') continue;
 
       if(!isset($attributes[$_attribute->attribute_key])){
         $attributes[$_attribute->attribute_key] = [];


### PR DESCRIPTION
カレンダー・カレンダー設定のステータス検索条件に、ダミーを表示する
ダミーのステータスでフィルタリングできること

〇確認方法
/calendars
/calendar_settings
/teachers/1/schedule?list=history
/teachers/1/calendar

検索条件にステータス＝ダミーで表示されること
適切に動作すること