### PR TITLE
保守対応（退会承認時の講師連絡他）

### DIFF
--- a/app/Models/Student.php
+++ b/app/Models/Student.php
@@ -1106,7 +1106,7 @@ EOT;
     $current_schedule = $this->get_current_schedule();
     if(isset($current_schedule)){
       foreach($current_schedule as $c){
-        $ret[$c->user_id] = $c->user->teacher;
+        $ret[$c->user->teacher->id] = $c->user->teacher;
       }
     }
     if(count($ret)==0){
@@ -1116,7 +1116,7 @@ EOT;
         foreach($calendar_settings[$lesson] as $method => $v1){
           foreach($v1 as $w => $_settings){
             foreach($_settings as $setting){
-              $ret[$setting->user_id] = $setting->user->teacher;
+              $ret[$setting->user->teacher->id] = $setting->user->teacher;
             }
           }
         }

--- a/app/Models/Student.php
+++ b/app/Models/Student.php
@@ -761,6 +761,15 @@ EOT;
         'unsubscribe_date' => $start_date,
       ]);
       $this->unsubscribe();
+      $current_charge_teachers = $this->get_current_charge_teachers();
+      foreach($current_charge_teachers as $teacher){
+        $teacher->user->send_mail('生徒様退会についてのご連絡', [
+          'send_to' => 'teacher',
+          'student_name' => $this->name(),
+          'unsubscribe_date' => $this->dateweek_format($start_date),
+        ], 'text', 'unsubscribe_complete');
+      }
+
     }
   }
   public function unsubscribe(){
@@ -1084,5 +1093,39 @@ EOT;
     //入会後の体験申し込み機能リリース以前の場合
     if(strtotime($this->created_at) < strtotime('2020-09-17 00:00:00')) return true;
     return false;
+  }
+
+  public function get_current_charge_teachers(){
+    $ret = [];
+    $current_schedule = $this->get_current_schedule();
+    if(isset($current_schedule)){
+      foreach($current_schedule as $c){
+        $ret[$c->user_id] = $c->user->teacher;
+      }
+    }
+    if(count($ret)==0){
+      $lesson = 1;
+      $calendar_settings = $this->user->get_enable_lesson_calendar_settings();
+      if(isset($calendar_settings) && isset($calendar_settings[$lesson])){
+        foreach($calendar_settings[$lesson] as $method => $v1){
+          foreach($v1 as $w => $_settings){
+            foreach($_settings as $setting){
+              $ret[$setting->user_id] = $setting->user->teacher;
+            }
+          }
+        }
+      }
+    }
+    return $ret;
+  }
+  public function get_current_schedule(){
+    //1か月前の通常授業をベースに担当の講師を取得する
+    $s = date('Y-m-1 00:00:00', strtotime('-1 month'));
+    \Log::warning("get_current_schedule");
+    $c = UserCalendar::findUser($this->user_id)
+                    ->where('teaching_type', 'regular')
+                    ->where('start_time', '>', $s)
+                    ->where('status', 'presence')->orderBy('start_time', 'desc')->get();
+    return $c;
   }
 }

--- a/app/Models/Student.php
+++ b/app/Models/Student.php
@@ -763,9 +763,11 @@ EOT;
       $this->unsubscribe();
       $current_charge_teachers = $this->get_current_charge_teachers();
       foreach($current_charge_teachers as $teacher){
-        $teacher->user->send_mail('生徒様退会についてのご連絡', [
+        $title = '生徒様退会についてのご連絡';
+        if($teacher->user->locale=='en') $title = 'Contact about student unsubscribe';
+        $teacher->user->send_mail($title, [
           'send_to' => 'teacher',
-          'student_name' => $this->name(),
+          'student' => $this,
           'unsubscribe_date' => $this->dateweek_format($start_date),
         ], 'text', 'unsubscribe_complete');
       }

--- a/app/Models/Student.php
+++ b/app/Models/Student.php
@@ -764,11 +764,15 @@ EOT;
       $current_charge_teachers = $this->get_current_charge_teachers();
       foreach($current_charge_teachers as $teacher){
         $title = '生徒様退会についてのご連絡';
-        if($teacher->user->locale=='en') $title = 'Contact about student unsubscribe';
+        $unsubscribe_date = $this->dateweek_format($start_date);
+        if($teacher->user->locale=='en') {
+          $title = 'Contact about student unsubscribe';
+          $unsubscribe_date = $start_date;
+        }
         $teacher->user->send_mail($title, [
           'send_to' => 'teacher',
           'student' => $this,
-          'unsubscribe_date' => $this->dateweek_format($start_date),
+          'unsubscribe_date' => $unsubscribe_date,
         ], 'text', 'unsubscribe_complete');
       }
 

--- a/app/Models/Teacher.php
+++ b/app/Models/Teacher.php
@@ -192,7 +192,9 @@ EOT;
       if(empty($form[$tag_name])) $form[$tag_name] = '';
       UserTag::setTag($this->user_id, $tag_name, $form[$tag_name], $form['create_user_id']);
     }
-    $this->user->update(['status' => 0]);
+    if(!empty($form['locale'])){
+      $this->user->update(['locale' => $form['locale']]);
+    }
   }
   public function is_manager(){
     $manager = Manager::where('user_id', $this->user_id)->first();

--- a/app/Models/Traits/Common.php
+++ b/app/Models/Traits/Common.php
@@ -85,7 +85,7 @@ trait Common
     $res = $controller->call_api($req, $url, $method, $data);
     return $res;
   }
-  public function dateweek_format($date, $format = "n月j日"){
+  public function dateweek_format($date, $format = "Y年n月j日"){
     if(empty($date)) return "-";
 
     $date = str_replace('/', '-', $date);

--- a/resources/lang/en/labels.php
+++ b/resources/lang/en/labels.php
@@ -1,6 +1,8 @@
 <?php
 
 return [
+  'ja' => 'Japanese',
+  'en' => 'English',
   'system_name' => 'SaKuRa One Net',
   'yes' => 'Yes',
   'no' => 'No',

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -161,4 +161,6 @@ return [
  'confirm_dummy_release' => 'Do you want to release the dummy status?',
  'mail_reply_recomend' => "＊This e-mail is for sending only, so we cannot reply to you. \n＊If you want to reply, you should use SaKuRa One Net.",
  'info_season_lesson_week_time' => "Season Lesson and Weekend Lesson, we will check the dates and times when you can work separately.\nAt that time, we will contact you as if you can work on the days and hours set above.",
+ "info_unsubscribe_for_teacher1" => ":student_name様は、下記の日付にて退会予定となります。",
+ "info_unsubscribe_for_teacher2" => "About exchange lessons, make sure to do it by the scheduled unsubscribe date.\nPlease register for the exchange lesson.",
  ];

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -161,6 +161,6 @@ return [
  'confirm_dummy_release' => 'Do you want to release the dummy status?',
  'mail_reply_recomend' => "＊This e-mail is for sending only, so we cannot reply to you. \n＊If you want to reply, you should use SaKuRa One Net.",
  'info_season_lesson_week_time' => "Season Lesson and Weekend Lesson, we will check the dates and times when you can work separately.\nAt that time, we will contact you as if you can work on the days and hours set above.",
- "info_unsubscribe_for_teacher1" => ":student_name様は、下記の日付にて退会予定となります。",
+ "info_unsubscribe_for_teacher1" => ":student_name will be unsubscribe on the following dates.",
  "info_unsubscribe_for_teacher2" => "About exchange lessons, make sure to do it by the scheduled unsubscribe date.\nPlease register for the exchange lesson.",
  ];

--- a/resources/lang/ja/labels.php
+++ b/resources/lang/ja/labels.php
@@ -1,6 +1,8 @@
 <?php
 
 return [
+  'ja' => '日本語',
+  'en' => 'English',
   'system_name' => 'SaKuRa One Net',
   'yes' => 'はい',
   'no' => 'いいえ',

--- a/resources/lang/ja/messages.php
+++ b/resources/lang/ja/messages.php
@@ -161,4 +161,6 @@ return [
   'confirm_dummy_release' => 'ダミーステータスを解除しますか？',
   'mail_reply_recomend' => "＊本メールは送信専用ですので、ご返信できません。\n＊ご返信は、SaKuRa One Netのメッセージ一覧をご利用ください。",
   "info_season_lesson_week_time" => "春期・夏期・冬期の講習、土日講習については、別途勤務可能な日時の確認を行います。\nその際、上記の設定の曜日・時間帯は勤務可能として連絡を行います。",
+  "info_unsubscribe_for_teacher1" => ":student_name様は、下記の日付にて退会予定となります。",
+  "info_unsubscribe_for_teacher2" => "振替授業については、退会予定日までに行うように、\n授業の登録をお願いいたします。",
 ];

--- a/resources/views/emails/unsubscribe_complete_text.blade.php
+++ b/resources/views/emails/unsubscribe_complete_text.blade.php
@@ -1,0 +1,11 @@
+@include('emails.common')
+
+{{$student_name}} 様は、下記の日付にて退会予定となります。
+
+{{__('labels.unsubscribe')}}{{__('labels.day')}}: {{$unsubscribe_date}}
+
+振替授業については、退会予定日までに行うように、
+授業の登録をお願いいたします。
+
+…………………………………………………………………………………………
+@yield('signature')

--- a/resources/views/emails/unsubscribe_complete_text.blade.php
+++ b/resources/views/emails/unsubscribe_complete_text.blade.php
@@ -1,11 +1,10 @@
 @include('emails.common')
 
-{{$student_name}} 様は、下記の日付にて退会予定となります。
+{{__('messages.info_unsubscribe_for_teacher1', ['student_name'=>$student->name()])}}
 
 {{__('labels.unsubscribe')}}{{__('labels.day')}}: {{$unsubscribe_date}}
 
-振替授業については、退会予定日までに行うように、
-授業の登録をお願いいたします。
+{{__('messages.info_unsubscribe_for_teacher2')}}
 
 …………………………………………………………………………………………
 @yield('signature')

--- a/resources/views/teachers/create_form.blade.php
+++ b/resources/views/teachers/create_form.blade.php
@@ -31,6 +31,8 @@
   </div>
   @component('students.forms.address', ['_edit'=>$_edit, 'item' => $item, 'attributes' => $attributes]) @endcomponent
   @component('students.forms.phoneno', ['_edit'=>$_edit, 'item'=>$item, 'attributes' => $attributes, 'prefix'=>'',]) @endcomponent
+  @component('teachers.forms.select_locale', ['_edit'=>$_edit, 'item'=>$item, 'attributes' => $attributes])@endcomponent
+
 </div>
 @endsection
 

--- a/resources/views/teachers/entry_form.blade.php
+++ b/resources/views/teachers/entry_form.blade.php
@@ -19,7 +19,7 @@
     <div class="row">
       @component('students.forms.name', ['attributes' => $attributes, 'prefix'=>'']) @endcomponent
       @component('students.forms.email', [ 'attributes' => $attributes, 'prefix'=>'']) @endcomponent
-      @component('teachers.forms.select_locale')@endcomponent
+      @component('teachers.forms.select_locale', ['_edit'=>false])@endcomponent
     </div>
     <div class="col-12">
       <h6 class="text-sm p-2 pl-2 mb-4" >

--- a/resources/views/teachers/forms/bank_form.blade.php
+++ b/resources/views/teachers/forms/bank_form.blade.php
@@ -9,9 +9,9 @@
     <div class="form-group">
       <label for="bank_no">
         {{__('labels.bank_no')}}
-        <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
+        <span class="right badge badge-secondary ml-1">{{__('labels.optional')}}</span>
       </label>
-      <input type="text" name="bank_no" class="form-control" placeholder="ex.0006" required="true" inputtype="number"
+      <input type="text" name="bank_no" class="form-control" placeholder="ex.0006" inputtype="number"
       @isset($item)
         value="{{$item['bank_no']}}"
       @else
@@ -24,9 +24,9 @@
     <div class="form-group">
       <label for="bank_branch_no">
         {{__('labels.bank_branch_no')}}
-        <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
+        <span class="right badge badge-secondary ml-1">{{__('labels.optional')}}</span>
       </label>
-      <input type="text" name="bank_branch_no" class="form-control" placeholder="ex.215" required="true" inputtype="number"
+      <input type="text" name="bank_branch_no" class="form-control" placeholder="ex.215" inputtype="number"
       @isset($item)
         value="{{$item['bank_branch_no']}}"
       @endisset
@@ -37,11 +37,11 @@
     <div class="form-group">
       <label for="bank_account_type" class="w-100">
         {{__('labels.bank_account_type')}}
-        <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
+        <span class="right badge badge-secondary ml-1">{{__('labels.optional')}}</span>
       </label>
       @foreach($attributes['bank_account_type'] as $index => $name)
       <label class="mx-2">
-        <input type="radio" value="{{ $index }}" name="bank_account_type" class="icheck flat-green" required="true"
+        <input type="radio" value="{{ $index }}" name="bank_account_type" class="icheck flat-green"
         @if($_edit===true && isset($item) && $item['bank_account_type'] == $index)
         checked
         @endif
@@ -54,9 +54,9 @@
     <div class="form-group">
       <label for="bank_account_no">
         {{__('labels.bank_account_no')}}
-        <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
+        <span class="right badge badge-secondary ml-1">{{__('labels.optional')}}</span>
       </label>
-      <input type="text" name="bank_account_no" class="form-control" placeholder="ex.0012345" required="true" inputtype="number"
+      <input type="text" name="bank_account_no" class="form-control" placeholder="ex.0012345" inputtype="number"
       @isset($item)
         value="{{$item['bank_account_no']}}"
       @endisset
@@ -67,9 +67,9 @@
     <div class="form-group">
       <label for="bank_account_name">
         {{__('labels.bank_account_name')}}
-        <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
+        <span class="right badge badge-secondary ml-1">{{__('labels.optional')}}</span>
       </label>
-      <input type="text" name="bank_account_name" class="form-control" placeholder="ex.ハチオウジ タロウ" required="true" inputtype="zenkakukana"
+      <input type="text" name="bank_account_name" class="form-control" placeholder="ex.ハチオウジ タロウ" inputtype="zenkakukana"
       @isset($item)
         value="{{$item['bank_account_name']}}"
       @endisset

--- a/resources/views/teachers/forms/select_locale.blade.php
+++ b/resources/views/teachers/forms/select_locale.blade.php
@@ -5,15 +5,23 @@
   <span class="badge badge-danger ml-1">{{__('labels.required')}}</span>
   <div class="input-group">
     <div class="form-check">
-      <input class="frm-check-input icheck flat-green" type="radio" name="locale" id="locale" value="ja" required="true" checked>
-      <label class="form-check-label" for="locale">
-        日本語
+      <input class="frm-check-input icheck flat-green" type="radio" name="locale" id="locale_ja" value="ja" required="true"
+      @if($_edit==false || ($_edit==true && $item->user->locale=='ja'))
+      checked
+      @endif
+      >
+      <label class="form-check-label" for="locale_ja">
+        {{__('labels.ja')}}
       </label>
     </div>
     <div class="form-check">
-      <input class="frm-check-input icheck flat-green" type="radio" name="locale" id="locale" value="en" required="true">
-      <label class="form-check-label" for="locale">
-        English
+      <input class="frm-check-input icheck flat-green" type="radio" name="locale" id="locale_en" value="en" required="true"
+      @if($_edit==true && $item->user->locale=='en')
+      checked
+      @endif
+      >
+      <label class="form-check-label" for="locale_en">
+        {{__('labels.en')}}
       </label>
     </div>
   </div>


### PR DESCRIPTION
〇保守対応
退会承認時の講師への連絡
講師の給与口座関連のフォームを必須→任意
バグ？というかコード最適化
言語設定のラベル→ローカライズ対応

〇確認方法
★退会承認時の講師への連絡
1. 契約者詳細＞生徒の退会連絡
2. 事務管理者ＴＯＰ＞退会連絡一覧＞承認
※メールが飛ぶこと
※メールの文面が適切であること
※連絡される講師は、直近1か月に出席の予定をもっている講師です

★講師の給与口座関連のフォームを必須→任意

1. 講師の詳細＞講師設定＞更新
2. 講師一覧＞講師新規登録（仮登録依頼）＞メールより本登録可能

※言語設定ができるようになっている＞更新も可能
※振込情報が任意になっている

