### PR TITLE
保守対応：自宅（オンライン）を申し込みにて選択できるようにする

### DIFF
--- a/app/Models/Place.php
+++ b/app/Models/Place.php
@@ -33,11 +33,16 @@ class Place extends Model
     }
     return false;
   }
+  //自宅という文字を含むかどうか
+  //自宅の場合は地図表示不要などに利用する
+  public function is_home(){
+    if(strpos($this->name, '自宅')!==false) return true;
+    return false;
+  }
   public function getIsUseAttribute(){
     if($this->is_use()==true) return '使用中';
     return '未使用';
   }
-
   public function scopeSearchWord($query, $word){
     $search_words = $this->get_search_word_array($word);
     $query = $query->where(function($query)use($search_words){

--- a/app/Models/Traits/Common.php
+++ b/app/Models/Traits/Common.php
@@ -264,4 +264,8 @@ trait Common
     $end_hour_minute = date($format,  strtotime($to));
     return $start_hour_minute.'～'.$end_hour_minute;
   }
+  public function is_online(){
+    if($this->has_tag('is_online', 'true')) return true;
+    return false;
+  }
 }

--- a/app/Models/UserCalendar.php
+++ b/app/Models/UserCalendar.php
@@ -305,10 +305,6 @@ EOT;
     if($d < 0) return false;
     return true;
   }
-  public function is_online(){
-    if($this->has_tag('is_online', 'true')) return true;
-    return false;
-  }
   //振替対象の場合:true
   public function is_exchange_target(){
     if($this->is_single()==false) return false;
@@ -846,6 +842,10 @@ EOT;
     if($this->trial_id > 0 && isset($form['status'])){
       //体験授業予定の場合、体験授業のステータスも更新する
       Trial::where('id', $this->trial_id)->first()->update(['status' => $status]);
+    }
+    if($this->place_floor->place->is_home()==true){
+      //自宅の場合はオンラインタグを付与
+      $form['is_online'] = 'true';
     }
     //TODO 将来的にsubject_exprに関するロジックは不要
     $tag_names = ['matching_decide_word', 'course_type', 'lesson', 'subject_expr', 'is_online'];

--- a/app/Models/UserCalendarSetting.php
+++ b/app/Models/UserCalendarSetting.php
@@ -428,6 +428,12 @@ EOT;
     }
     $this->cache_delete();
     UserCalendarSetting::where('id', $this->id)->update($data);
+
+    if($this->place_floor->place->is_home()==true){
+      //自宅の場合はオンラインタグを付与
+      $form['is_online'] = 'true';
+    }
+
     $tag_names = ['course_type', 'lesson', 'is_online'];
     foreach($tag_names as $tag_name){
       if(!empty($form[$tag_name])){

--- a/resources/views/calendar_settings/forms/lesson_place_floor.blade.php
+++ b/resources/views/calendar_settings/forms/lesson_place_floor.blade.php
@@ -1,26 +1,31 @@
-<div class="col-12 col-md-6 mt-2">
+<div class="col-12 mt-2">
   <div class="form-group">
     <label for="lesson_place_floor" class="w-100">
       {{__('labels.place')}}
       <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
     </label>
-    <select name="place_floor_id" class="form-control" width="100%" required="true" >
-      <option value="">{{__('labels.selectable')}}</option>
-      @foreach($attributes['places'] as $place)
-        @foreach($place->floors as $floor)
-        @if(isset($item["tagdata"]) && isset($item["tagdata"]["lesson_place"]) && isset($item["tagdata"]["lesson_place"][$place->id]))
-          <option value="{{$floor->id}}"
-            @if(isset($calendar) && $calendar->place_floor_id==$floor->id)
-              selected
-            @elseif(isset($item->place_floor_id) && $item->place_floor_id==$floor->id)
-              selected
-            @elseif($loop->index==0)
-              selected
+    <div class="input-group">
+      <div class="input-group-prepend">
+        <span class="input-group-text"><i class="fa fa-map-marker-alt"></i></span>
+      </div>
+      <select name='place_floor_id' class="form-control" required="true">
+        <option value="">{{__('labels.selectable')}}</option>
+        @foreach($attributes['places'] as $place)
+          @foreach($place->floors as $floor)
+          @if(isset($item["tagdata"]) && isset($item["tagdata"]["lesson_place"]) && isset($item["tagdata"]["lesson_place"][$place->id]))
+            <option value="{{$floor->id}}"
+              @if(isset($calendar) && $calendar->place_floor_id==$floor->id)
+                selected
+              @elseif(isset($item->place_floor_id) && $item->place_floor_id==$floor->id)
+                selected
+              @elseif($loop->index==0)
+                selected
+              @endif
+            >{{$floor->name()}}</option>
             @endif
-          >{{$floor->name()}}</option>
-          @endif
+          @endforeach
         @endforeach
-      @endforeach
-    </select>
+      </select>
+    </div>
   </div>
 </div>

--- a/resources/views/students/forms/lesson_place.blade.php
+++ b/resources/views/students/forms/lesson_place.blade.php
@@ -10,16 +10,17 @@
     </label>
     @foreach($attributes['places'] as $place)
     @if($place->name=='本校') @continue @endif
-    @if($place->name=='自宅') @continue @endif
     <label class="mx-2 lesson_place">
       <input type="checkbox" value="{{$place->id}}" name="lesson_place[]" class="icheck flat-green" required="true"
       @if($_edit===true && isset($item) && $item->has_tag("lesson_place", $place->id))
       checked
       @endif
       >{{$place->name}}
+      @if($place->is_home()==false)
       <a href="javascript:void(0);"
         onclick="window.open('http://maps.google.co.jp/maps?q='+encodeURI('{{$place->address}}'));return false;">[MAP]
       </a>
+      @endif
     </label>
     @endforeach
   </div>

--- a/resources/views/students/forms/lesson_place.blade.php
+++ b/resources/views/students/forms/lesson_place.blade.php
@@ -15,8 +15,11 @@
       @if($_edit===true && isset($item) && $item->has_tag("lesson_place", $place->id))
       checked
       @endif
-      >{{$place->name}}
-      @if($place->is_home()==false)
+      >
+      @if($place->is_home()==true)
+      自宅（オンライン授業）
+      @else
+      {{$place->name}}
       <a href="javascript:void(0);"
         onclick="window.open('http://maps.google.co.jp/maps?q='+encodeURI('{{$place->address}}'));return false;">[MAP]
       </a>

--- a/resources/views/trials/create_form.blade.php
+++ b/resources/views/trials/create_form.blade.php
@@ -13,7 +13,7 @@
   @component('students.forms.lesson_place', ['_edit'=>$_edit, 'item'=>$item, 'attributes' => $attributes]) @endcomponent
   <div class="col-12">
     <div class="form-group">
-      <label for="regular_schedule_exchange">
+      <label for="parent_interview">
         体験授業当日に入会等の説明を希望しますか
         <span class="right badge badge-danger ml-1">{{__('labels.required')}}</span>
       </label>

--- a/resources/views/trials/forms/trial_calendar.blade.php
+++ b/resources/views/trials/forms/trial_calendar.blade.php
@@ -15,10 +15,10 @@
           {{$calendar['place_floor_name']}}
           </a>
         </span>
+        <br>
         <small class="badge badge-{{config('status_style')[$calendar->status]}} mx-2">
           {{$calendar["status_name"]}}
         </small>
-        <br>
         <span class="description-text mr-2">
         @foreach($calendar['teachers'] as $member)
           <a href='/teachers/{{$member->user->teacher->id}}'>
@@ -34,6 +34,11 @@
           </small>
         </span>
         @endforeach
+        @if($calendar->is_online()==true)
+        <small class="badge badge-info mx-1 text-sm">
+          <i class="fa fa-globe">{{__('labels.online')}}</i>
+        </small>
+        @endif
       </div>
       @if($calendar->status=='dummy' || $calendar->status=='new' || $calendar->status=='confirm' || $calendar->status=='cancel')
       <div class="col-12 col-md-3 my-1">

--- a/resources/views/trials/to_calendar.blade.php
+++ b/resources/views/trials/to_calendar.blade.php
@@ -43,7 +43,7 @@
                     </button>
                 </div>
                 <div class="col-6 mb-1">
-                  <a href="/{{$domain}}/{{$item->id}}" role="button" class="btn-prev btn btn-secondary btn-block float-left mr-1">
+                  <a href="/{{$domain}}/{{$item->id}}" role="button" class="btn btn-secondary btn-block float-left mr-1 btn-block">
                     <i class="fa fa-arrow-circle-left mr-1"></i>
                     キャンセル
                   </a>
@@ -55,20 +55,24 @@
                 {{-- TODO dummyを中継するので、通知を登録時にしなくてよい
                 @component('calendars.forms.mail_send_confirm', ['default_send_teacher' => true]); @endcomponent
                 --}}
+                @endif
+              </div>
+              @if(count($candidate_teachers[0]->trial) > 0)
+              <div class="row">
                 <div class="col-6 mb-1">
-                  <a href="/{{$domain}}/{{$item->id}}" role="button" class="btn-prev btn btn-secondary btn-block float-left mr-1">
+                  <a href="/{{$domain}}/{{$item->id}}" role="button" class="btn btn-secondary float-left mr-1 btn-block">
                     <i class="fa fa-arrow-circle-left mr-1"></i>
                     {{__('labels.cancel_button')}}
                   </a>
                 </div>
                 <div class="col-6 mb-1">
-                    <button type="button" class="btn btn-submit btn-primary btn-block">
-                      <i class="fa fa-check mr-1"></i>
-                      {{__('labels.add_button')}}
-                    </button>
+                  <button type="button" class="btn btn-submit btn-primary btn-block">
+                    <i class="fa fa-check mr-1"></i>
+                    {{__('labels.add_button')}}
+                  </button>
                 </div>
-                @endif
               </div>
+              @endif
             </div>
           </div>
 


### PR DESCRIPTION
Place::is_home追加 …
 自宅という文字がある＝is_home=true

Common.php
 UserCalendar.phpから、is_onlineを移設（is_online / trueタグが存在する）

to_calendar.blade.php
 ステータス部分・オンライン部分のbadgeを2段目に移動

申し込み時の自宅表記→自宅（オンライン授業）とする …
カレンダー設定の更新も、自宅＝オンラインタグ付与

〇確認方法
①体験申し込み＞希望する教室＝自宅（オンライン授業）が選択できる
②この申し込みにたいする体験授業登録時にオンラインタグが自動付与される
③授業登録にて自宅を選択するとオンンラインタグが付与される
④カレンダー設定登録時も同様に場所＝自宅はオンラインタグ付与される