### PR TITLE
（オンライン授業対応）skype nameの登録に関する対応

### DIFF
--- a/app/Http/Controllers/UserCalendarController.php
+++ b/app/Http/Controllers/UserCalendarController.php
@@ -121,7 +121,7 @@ class UserCalendarController extends MilestoneController
       $ret = [
         'teacher_name' => [
           'label' => __('labels.teachers'),
-          'size' => 6,
+          'size' => 12,
         ],
         'lesson' => [
           'label' => __('labels.lesson'),

--- a/app/Http/Controllers/UserCalendarSettingController.php
+++ b/app/Http/Controllers/UserCalendarSettingController.php
@@ -92,12 +92,12 @@ class UserCalendarSettingController extends UserCalendarController
       }
       else {
         $ret = [
+          'teacher_name' => [
+            'label' => __('labels.teachers'),
+            'size' => 12,
+          ],
           'student_name' => [
             'label' => __('labels.students'),
-            'size' => 6,
-          ],
-          'user_name' => [
-            'label' => __('labels.teachers'),
             'size' => 6,
           ],
           'subject' => [

--- a/app/Models/Teacher.php
+++ b/app/Models/Teacher.php
@@ -175,7 +175,7 @@ EOT;
         UserTag::setTags($this->user_id, $tag_name, $form[$tag_name], $form['create_user_id']);
       }
     }
-    $tag_names = ['piano_level', 'english_teacher', 'schedule_remark'];
+    $tag_names = ['piano_level', 'english_teacher', 'schedule_remark', "skype_name"];
     foreach($tag_names as $tag_name){
       if(isset($form[$tag_name])){
         //設定があれば差し替え

--- a/app/Models/Traits/Common.php
+++ b/app/Models/Traits/Common.php
@@ -177,11 +177,13 @@ trait Common
     return $search_words;
   }
   public function has_tag($key, $val=""){
-    if(!isset($this->tags)) return null;
-    $tags = $this->tags;
-    foreach($tags as $tag){
-      if(empty($val) && $tag->tag_key==$key) return true;
-      if($tag->tag_key==$key && $tag->tag_value==$val) return true;
+    if(!isset($this->tags)) return false;
+    $tags = $this->tags->where('tag_key', $key);
+    if(empty($val)){
+      if(count($this->tags->where('tag_key', $key)) > 0) return true;
+    }
+    else {
+      if(count($this->tags->where('tag_key', $key)->where('tag_value', $val)) > 0) return true;
     }
     return false;
   }

--- a/resources/lang/en/labels.php
+++ b/resources/lang/en/labels.php
@@ -407,4 +407,6 @@ return [
   'menu' => 'Menu',
   'task_title' => 'ex: English_selfIntroduction',
   'workable_classroom' => 'Workable ClassRoom',
+  'skype_name' => 'Skype Name',
+  'skype_name_about' => 'What is my Skype ID?',
 ];

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -163,4 +163,5 @@ return [
  'info_season_lesson_week_time' => "Season Lesson and Weekend Lesson, we will check the dates and times when you can work separately.\nAt that time, we will contact you as if you can work on the days and hours set above.",
  "info_unsubscribe_for_teacher1" => ":student_name will be unsubscribe on the following dates.",
  "info_unsubscribe_for_teacher2" => "About exchange lessons, make sure to do it by the scheduled unsubscribe date.\nPlease register for the exchange lesson.",
+ "error_skype_name_not_found" => "For online classes, you need to set a Skype Name.\nPlease set the Skype Name from the work settings.",
  ];

--- a/resources/lang/ja/labels.php
+++ b/resources/lang/ja/labels.php
@@ -407,4 +407,6 @@ return [
   'menu' => 'メニュー',
   'task_title' => '例：算数_分数の足し算',
   'workable_classroom' => '勤務可能な教室',
+  'skype_name' => 'Skype名',
+  'skype_name_about' => 'Skype名の確認方法',
 ];

--- a/resources/lang/ja/messages.php
+++ b/resources/lang/ja/messages.php
@@ -163,4 +163,5 @@ return [
   "info_season_lesson_week_time" => "春期・夏期・冬期の講習、土日講習については、別途勤務可能な日時の確認を行います。\nその際、上記の設定の曜日・時間帯は勤務可能として連絡を行います。",
   "info_unsubscribe_for_teacher1" => ":student_name様は、下記の日付にて退会予定となります。",
   "info_unsubscribe_for_teacher2" => "振替授業については、退会予定日までに行うように、\n授業の登録をお願いいたします。",
+  "error_skype_name_not_found" => "オンライン授業の場合、Skype Nameの設定が必要です。\n勤務設定から、Skype Nameの設定をお願いいたします。",
 ];

--- a/resources/views/calendar_settings/confirm.blade.php
+++ b/resources/views/calendar_settings/confirm.blade.php
@@ -27,10 +27,18 @@
         @component('calendars.forms.to_status_form', ['item'=>$item, 'attributes' => $attributes]) @endcomponent
           <div class="col-12 mb-1" >
             <input type="hidden" name="is_all_student" value="1" />
+            @if($item->is_online()==true && $item->user->has_tag('skype_name')!=true)
+            <div class="col-12">
+              <div class="alert alert-danger text-sm">
+                <i class="icon fa fa-exclamation-triangle"></i>{!!nl2br(__('messages.error_skype_name_not_found'))!!}
+              </div>
+            </div>
+            @else
             <button type="button" class="btn btn-submit btn-success btn-block"  accesskey="{{$domain}}_confirm">
                 <i class="fa fa-check mr-1"></i>
                 {{__('labels.schedule_to_confirm')}}
             </button>
+            @endif
           </div>
       </form>
     </div>

--- a/resources/views/calendar_settings/page.blade.php
+++ b/resources/views/calendar_settings/page.blade.php
@@ -40,6 +40,14 @@
                 </small>
               @endif
             @endif
+          @elseif($key==='teacher_name')
+          <label for="{{$key}}" class="w-100">
+            {{$field['label']}}
+          </label>
+            @if($user->role=='manager') <a href="/teachers/{{$item->user->teacher->id}}" target="_blank"> @endif
+            {{$item[$key]}}
+            @if($item->is_online()==true && $item->user->has_tag('skype_name')==true)({{__('labels.skype_name')}}:{{$item->user->get_tag_value('skype_name')}})@endif
+            @if($user->role=='manager') </a> @endif
           @elseif($key==='student_name' && ($action!='delete' || $item->is_group()!=true))
             <label for="{{$key}}" class="w-100">
               {{$field['label']}}

--- a/resources/views/calendars/confirm.blade.php
+++ b/resources/views/calendars/confirm.blade.php
@@ -27,10 +27,18 @@
         @component('calendars.forms.to_status_form', ['item'=>$item, 'attributes' => $attributes]) @endcomponent
           <div class="col-12 mb-1" id="{{$domain}}_confirm">
             <input type="hidden" name="is_all_student" value="1" />
+            @if($item->is_online()==true && $item->user->has_tag('skype_name')!=true)
+            <div class="col-12">
+              <div class="alert alert-danger text-sm">
+                <i class="icon fa fa-exclamation-triangle"></i>{!!nl2br(__('messages.error_skype_name_not_found'))!!}
+              </div>
+            </div>
+            @else
             <button type="button" class="btn btn-submit btn-success btn-block"  accesskey="{{$domain}}_confirm">
                 <i class="fa fa-check mr-1"></i>
                 {{__('labels.schedule_to_confirm')}}
             </button>
+            @endif
           </div>
         </form>
       </div>

--- a/resources/views/calendars/page.blade.php
+++ b/resources/views/calendars/page.blade.php
@@ -46,11 +46,14 @@
             {{$field['label']}}
           </label>
           @component('calendars.forms.label_students', ['item' => $item, 'user'=>$user, 'set_br' => true , 'status_visible'=> true]) @endcomponent
-        @elseif($key==='teacher_name' && $user->role=='manager')
+        @elseif($key==='teacher_name')
         <label for="{{$key}}" class="w-100">
           {{$field['label']}}
         </label>
-        <a href="/teachers/{{$item->user->teacher->id}}" target="_blank">{{$item[$key]}}</a>
+          @if($user->role=='manager') <a href="/teachers/{{$item->user->teacher->id}}" target="_blank"> @endif
+          {{$item[$key]}}
+          @if($item->is_online()==true && $item->user->has_tag('skype_name')==true)({{__('labels.skype_name')}}:{{$item->user->get_tag_value('skype_name')}})@endif
+          @if($user->role=='manager') </a> @endif
         @elseif($key==='teaching_name' || $key==='course')
         <label for="{{$key}}" class="w-100">
           {{$field['label']}}

--- a/resources/views/emails/calendar_confirm_text.blade.php
+++ b/resources/views/emails/calendar_confirm_text.blade.php
@@ -3,7 +3,7 @@
 @if($send_to==='student')
 {{$user_name}} 様
 
-@if($item['trial_id'] > 0)
+@if($item->trial_id > 0)
 この度は、体験授業のお申込み、誠にありがとうございます。
 @endif
 

--- a/resources/views/emails/calendar_fix_text.blade.php
+++ b/resources/views/emails/calendar_fix_text.blade.php
@@ -10,7 +10,6 @@
 @component('emails.forms.calendar', ['item' => $item, 'send_to' => $send_to, 'login_user' => $login_user, 'notice', '']) @endcomponent
 …………………………………………………………………………………………
 @if($send_to==='student')
-…………………………………………………………………………………………
 授業をお休みする場合は、以下の画面よりご連絡ください。
 {{config('app.url')}}/calendars/{{$item['id']}}/status_update/rest?key={{$token}}&user={{$user->user_id}}
 

--- a/resources/views/emails/forms/calendar.blade.php
+++ b/resources/views/emails/forms/calendar.blade.php
@@ -14,7 +14,6 @@
 @if($send_to!=='student')
 ({{__('labels.status')}}：{{$item->status_name()}})
 @endif
---------------------------------------------
 （{{__('labels.details')}}）
 @if($item->is_teaching()==true)
 {{__('labels.teachers')}}：{{$item->user->details('teachers')->name()}}
@@ -31,7 +30,25 @@
 @endforeach
 @endif
 
---------------------------------------------
 @if($send_to!=='student' && (!isset($is_control) || $is_control==false))
 ({{__('labels.control')}}：{{$login_user["name"]}})
+@endif
+@if($send_to=='student')
+@if($item->trial_id > 0 && $item->has_tag('lesson', 1)==true)
+
+■持ち物
+1. 教科書、学校で使用している問題集
+2. 筆記用具
+3. ノート
+4. 過去の定期試験と模試
+@endif
+@if($item->is_online()==true && $item->user->has_tag('skype_name'))
+
+■オンライン授業について
+オンライン授業は、スカイプを利用いたします。
+スカイプがダウンロードされたパソコン・ダブレット・スマホで、講師のSkype名にてアカウントを検索していただけますと、
+担当講師と繋がります。
+
+※講師のSkype Name：{{$item->user->get_tag_value('skype_name')}}
+@endif
 @endif

--- a/resources/views/teachers/create_form.blade.php
+++ b/resources/views/teachers/create_form.blade.php
@@ -40,6 +40,7 @@
 <div class="row">
   @component('students.forms.lesson', ['_edit'=>$_edit, 'item'=>$item->user, 'attributes' => $attributes, 'prefix'=>'', 'title'=> __('labels.charge_lesson')]) @endcomponent
   @component('students.forms.lesson_place', ['title'=>__('labels.workable_classroom'), '_edit'=>$_edit, 'item'=>$item->user, 'attributes' => $attributes]) @endcomponent
+  @component('teachers.forms.skype_name', ['_edit'=>$_edit, 'item'=>$item->user, 'attributes' => $attributes]) @endcomponent
   @component('students.forms.work_time', ['_edit'=>$_edit, 'item'=>$item->user, 'prefix'=> 'lesson', 'attributes' => $attributes, 'title' => __('labels.lesson_week_time')]) @endcomponent
 </div>
 <div class="row">

--- a/resources/views/teachers/forms/skype_name.blade.php
+++ b/resources/views/teachers/forms/skype_name.blade.php
@@ -1,0 +1,16 @@
+<div class="col-12">
+  <div class="form-group">
+    <label for="skype_name">
+      Skype名
+      <span class="right badge badge-secondary ml-1">{{__('labels.optional')}}</span>
+    </label>
+    <input type="text" name="skype_name" class="form-control" placeholder="live:xxxxxxx" inputtype="hankaku"
+    @isset($item)
+      value="{{$item->get_tag_value('skype_name')}}"
+    @else
+      value=""
+    @endisset
+    maxlength=100>
+    <a href="https://support.skype.com/ja/faq/fa10858/skype-ming-tohahe-desuka" target="_blank">{{__('labels.skype_name_about')}}</a>
+  </div>
+</div>


### PR DESCRIPTION
①skype_nameを勤務設定で登録できるようにする
②講師予定確認時に、オンライン授業の場合、skype_nameが設定されているかどうかチェック
（設定されていない場合、確認操作は不可能にする）

③授業予定のメール内容
※オンライン授業の場合かつ、生徒への送信時に、
・体験授業＋塾の場合、持ち物に関する記述追加
・オンライン授業かつ、講師skype_name設定時に、オンライン授業に関する説明を追加

すべてskype_nameの判定を行うようにすると、過去の利用状態が壊れるので、
１．表示ＵＩに関しては、設定があれば表示
２．設定ＵＩに関しては、あらたにオンライン授業はskype_name設定なしではできない
のポリシーで実装しました