### PR TITLE
[fix] dbalとLaravelの不具合によりint型へ変更できない問題の回避策を入れる

### DIFF
--- a/database/migrations/2018_12_09_150309_change_image_id_textbooks.php
+++ b/database/migrations/2018_12_09_150309_change_image_id_textbooks.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
@@ -13,9 +14,7 @@ class ChangeImageIdTextbooks extends Migration
      */
     public function up()
     {
-        Schema::table('textbooks', function (Blueprint $table) {
-          $table->integer('image_id')->default(0)->change();
-        });
+        DB::statement("ALTER TABLE `textbooks` CHANGE COLUMN `image_id` `image_id` INT NOT NULL DEFAULT 0 COMMENT '本の写真など' AFTER `url`;");
     }
 
     /**

--- a/database/migrations/2019_06_22_152309_change_parent_ask_id_asks.php
+++ b/database/migrations/2019_06_22_152309_change_parent_ask_id_asks.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
@@ -13,9 +14,7 @@ class ChangeParentAskIdAsks extends Migration
      */
     public function up()
     {
-        Schema::table('asks', function (Blueprint $table) {
-          $table->integer('parent_ask_id')->default(0)->change();
-        });
+        DB::statement("ALTER TABLE `asks` CHANGE COLUMN `parent_ask_id` `parent_ask_id` INT NOT NULL DEFAULT 0 COMMENT '親依頼ID' AFTER `type`;");
     }
 
     /**


### PR DESCRIPTION
## 概要
最新develop環境において、Laravelのmigration実行した際、下記エラーが発生することを確認いたしました。
> SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'CHARACTER SET utf8 DEFAULT 0 NOT NULL COLLATE `utf8_unicode_ci` COMMENT '本のå' at line 1 (SQL: ALTER TABLE textbooks CHANGE image_id image_id INT CHARACTER SET utf8 DEFAULT 0 NOT NULL COLLATE `utf8_unicode_ci` COMMENT '本の写真など')

調査したところ、Laravelのmigartion機能で使われているdbalと呼ばれるライブラリとLaravelの相性があり、バージョンによってはstringからintに変換する際などに当該エラーが発生してしまうことを確認いたしました。

根本的な解消にはLaravelのバージョンを上げることが解決法ではございますが、当プルリクでは別の手法での回避策を施したコードが含まれております。

## 動作確認
migrationがエラーなく完了することを確認済みです

##  レビュワーへの参考情報
https://github.com/laravel/framework/issues/30539
https://readouble.com/laravel/5.8/ja/database.html