### PR TITLE
顧客レビューによる追加内容

### DIFF
--- a/resources/lang/en/labels.php
+++ b/resources/lang/en/labels.php
@@ -408,5 +408,5 @@ return [
   'task_title' => 'ex: English_selfIntroduction',
   'workable_classroom' => 'Workable ClassRoom',
   'skype_name' => 'Skype Name',
-  'skype_name_about' => 'What is my Skype ID?',
+  'skype_name_about' => 'Click here if you don't know how to check your Skype name',
 ];

--- a/resources/lang/ja/labels.php
+++ b/resources/lang/ja/labels.php
@@ -408,5 +408,5 @@ return [
   'task_title' => '例：算数_分数の足し算',
   'workable_classroom' => '勤務可能な教室',
   'skype_name' => 'Skype名',
-  'skype_name_about' => 'Skype名の確認方法',
+  'skype_name_about' => 'Skype名の確認方法がわからない場合、こちらをクリック',
 ];

--- a/resources/lang/ja/messages.php
+++ b/resources/lang/ja/messages.php
@@ -163,5 +163,5 @@ return [
   "info_season_lesson_week_time" => "春期・夏期・冬期の講習、土日講習については、別途勤務可能な日時の確認を行います。\nその際、上記の設定の曜日・時間帯は勤務可能として連絡を行います。",
   "info_unsubscribe_for_teacher1" => ":student_name様は、下記の日付にて退会予定となります。",
   "info_unsubscribe_for_teacher2" => "振替授業については、退会予定日までに行うように、\n授業の登録をお願いいたします。",
-  "error_skype_name_not_found" => "オンライン授業の場合、Skype Nameの設定が必要です。\n勤務設定から、Skype Nameの設定をお願いいたします。",
+  "error_skype_name_not_found" => "オンライン授業の場合、Skype名の設定が必要です。\n勤務設定から、Skype名の設定をお願いいたします。",
 ];

--- a/resources/views/calendars/confirm.blade.php
+++ b/resources/views/calendars/confirm.blade.php
@@ -27,7 +27,7 @@
         @component('calendars.forms.to_status_form', ['item'=>$item, 'attributes' => $attributes]) @endcomponent
           <div class="col-12 mb-1" id="{{$domain}}_confirm">
             <input type="hidden" name="is_all_student" value="1" />
-            @if($item->is_online()==true && $item->user->has_tag('skype_name')!=true)
+            @if($item->is_online()==true && empty($item->user->get_tag_value('skype_name')))
             <div class="col-12">
               <div class="alert alert-danger text-sm">
                 <i class="icon fa fa-exclamation-triangle"></i>{!!nl2br(__('messages.error_skype_name_not_found'))!!}

--- a/resources/views/calendars/page.blade.php
+++ b/resources/views/calendars/page.blade.php
@@ -194,6 +194,18 @@
     <form method="POST" action="/{{$domain}}/{{$item['id']}}/status_update/new">
     @csrf
     <input type="text" name="dummy" style="display:none;" / >
+    @if(empty($item->user->teacher->get_tag_value('skype_name')))
+    <div class="row">
+      <div class="col-12 mb-1">
+        <div class="form-group">
+          <input class="form-check-input icheck flat-red" type="checkbox" id="skype_name_check" name="skype_name_check" value="1" required="true">
+          <label class="form-check-label" for="skype_name_check">
+            <i class="fa fa-exclamation-triangle mr-1"></i>講師のSkype名が設定されていないことを確認しました
+          </label>
+        </div>
+      </div>
+    </div>
+    @endif
     <div class="row">
       @method('PUT')
       <div class="col-12 col-md-6 mb-1">

--- a/resources/views/emails/forms/calendar.blade.php
+++ b/resources/views/emails/forms/calendar.blade.php
@@ -49,6 +49,10 @@
 スカイプがダウンロードされたパソコン・ダブレット・スマホで、講師のSkype名にてアカウントを検索していただけますと、
 担当講師と繋がります。
 
-※講師のSkype Name：{{$item->user->get_tag_value('skype_name')}}
+※講師のSkype名{{$item->user->get_tag_value('skype_name')}}
+
+※Skype名にてアカウント登録の方法がご不明な場合は、以下をご確認ください
+https://support.skype.com/ja/faq/fa34807/skype-dexin-shiilian-luo-xian-wojian-tsukerufang-fa
+
 @endif
 @endif

--- a/resources/views/teachers/forms/skype_name.blade.php
+++ b/resources/views/teachers/forms/skype_name.blade.php
@@ -11,6 +11,6 @@
       value=""
     @endisset
     maxlength=100>
-    <a href="https://support.skype.com/ja/faq/fa10858/skype-ming-tohahe-desuka" target="_blank">{{__('labels.skype_name_about')}}</a>
+    <a href="https://support.skype.com/ja/faq/fa10858/skype-ming-tohahe-desuka" target="_blank" class="underline">{{__('labels.skype_name_about')}}</a>
   </div>
 </div>


### PR DESCRIPTION
①ダミー解除の際、skype nameの設定がない場合、
設定がないことを確認させるフォーム追加
確認したにチェｃック　→　ダミー解除する

②メールに、Skype名にてアカウント登録の方法がご不明な場合の文言・リンク追加

その他修正
skype_nameが設定かどうかの判定
has_tagだと、タグはあるが空文字のケースがあるので、
get_tag_valueにて、emptyかどうかにする

Skype名設定のすぐ下にあるサポート文言を変更
スタイルもリンクだとわかるようにunderlineにしといた
Skype名の確認方法　→　Skype名の確認方法がわからない場合、こちらをクリック