### PR TITLE
仕様漏れ

### DIFF
--- a/resources/views/calendar_settings/confirm.blade.php
+++ b/resources/views/calendar_settings/confirm.blade.php
@@ -69,18 +69,7 @@
     </div>
     @endif
 
-    <div class="col-12 col-lg-6 mb-1" id="{{$domain}}_action">
-      <form method="POST" action="/calendar_settings/{{$item['id']}}">
-        @csrf
-        <input type="text" name="dummy" style="display:none;" / >
-        @method('DELETE')
-        <button type="button" class="btn btn-submit btn-danger btn-block"  accesskey="{{$domain}}_action" confirm="{{__('messages.confirm_delete')}}">
-          <i class="fa fa-trash-alt mr-1"></i>
-          {{__('labels.schedule_delete')}}
-        </button>
-      </form>
-    </div>
-    <div class="col-12 col-lg-6 mb-1">
+    <div class="col-12 mb-1">
       <button type="reset" class="btn btn-secondary btn-block">
           {{__('labels.close_button')}}
       </button>

--- a/resources/views/calendar_settings/page.blade.php
+++ b/resources/views/calendar_settings/page.blade.php
@@ -154,6 +154,18 @@
     <form method="POST" action="/{{$domain}}/{{$item['id']}}/status_update/new">
     @csrf
     <input type="text" name="dummy" style="display:none;" / >
+    @if($item->is_online()==true && empty($item->user->teacher->get_tag_value('skype_name')))
+    <div class="row">
+      <div class="col-12 mb-1">
+        <div class="form-group">
+          <input class="form-check-input icheck flat-red" type="checkbox" id="skype_name_check" name="skype_name_check" value="1" required="true">
+          <label class="form-check-label" for="skype_name_check">
+            <i class="fa fa-exclamation-triangle mr-1"></i>講師のSkype名が設定されていないことを確認しました
+          </label>
+        </div>
+      </div>
+    </div>
+    @endif
     <div class="row">
       @method('PUT')
       <div class="col-12 col-md-6 mb-1">

--- a/resources/views/calendars/page.blade.php
+++ b/resources/views/calendars/page.blade.php
@@ -194,7 +194,7 @@
     <form method="POST" action="/{{$domain}}/{{$item['id']}}/status_update/new">
     @csrf
     <input type="text" name="dummy" style="display:none;" / >
-    @if(empty($item->user->teacher->get_tag_value('skype_name')))
+    @if($item->is_online()==true empty($item->user->teacher->get_tag_value('skype_name')))
     <div class="row">
       <div class="col-12 mb-1">
         <div class="form-group">


### PR DESCRIPTION
カレンダー設定確認時の削除ボタン除去
　→　削除できてはいけない気がする

カレンダー設定のオンライン授業のダミー解除時に、
Skype名設定の有無を確認するcheckboxを表示

カレンダーのオンライン授業のダミー解除時に、
Skype名設定の有無を確認するcheckboxを表示
（オンラインという条件がぬけてた）