### PR TITLE
UserCalenderModel内メソッドの中括弧が正しく閉じられていない問題の修正

### DIFF
--- a/app/Models/UserCalendar.php
+++ b/app/Models/UserCalendar.php
@@ -1346,17 +1346,18 @@ EOT;
   }
 
 
-  public function agreement_update($user_id){
-    $agreement_member =  UserCalendarMemberSetting::where('user_id',$user_id)->get();
-    if($agreement_member->count() > 0 ){
-      //設定が残るなら契約更新
-      Agreement::add_from_member_setting($agreement_member->first()->id);
-    }else{
-      //有効な設定がなければ契約無効化
-      $student_id = Student::where('user_id',$user_id)->first()->id;
-      Agreement::where('student_id',$student_id)->update(['end_date' => date('Y/m/d H:i:s')]);
-    }
-
+  public function agreement_update($user_id)
+  {
+      $agreement_member = UserCalendarMemberSetting::where('user_id', $user_id)->get();
+      if ($agreement_member->count() > 0) {
+          //設定が残るなら契約更新
+          Agreement::add_from_member_setting($agreement_member->first()->id);
+      } else {
+          //有効な設定がなければ契約無効化
+          $student_id = Student::where('user_id', $user_id)->first()->id;
+          Agreement::where('student_id', $student_id)->update(['end_date' => date('Y/m/d H:i:s')]);
+      }
+  }
   public function is_first_place(){
     $place_floor_ids = PlaceFloor::where('place_id', $this->place_floor->place_id)->pluck('id');
     $c = self::where('user_id', $this->user_id)


### PR DESCRIPTION
最新版のdevelopを確認したところ、

`PHP Parse error:  syntax error, unexpected 'public'`

上記エラーが発生しており、Modelクラスでメソッドの中括弧が正しく閉じられていないことを確認したしましたので修正いたしました。

蛇足：
![image](https://user-images.githubusercontent.com/78639175/110967821-255d3600-839a-11eb-9213-edcf4d011bd0.png)
こちら私のIDEの画面ですが、誤っているとエラー表示してくれるので大変便利です。
※中括弧閉じていない箇所以外もエラー発生しているのは私のIDEの警告設定を鬼教官並にルールを厳しくしている影響です