### PR TITLE
体験申し込み一覧のソート順を日付降順に変更

### DIFF
--- a/app/Http/Controllers/TrialController.php
+++ b/app/Http/Controllers/TrialController.php
@@ -226,11 +226,12 @@ class TrialController extends UserCalendarController
     $count = $items->count();
 
     $request->merge([
-      '_sort' => 'created_at'
+      '_sort' => 'created_at',
+      '_sort_order' => 'desc'
     ]);
-    if($request->get('is_desc')==1){
+    if($request->get('is_asc')==1){
       $request->merge([
-        '_sort_order' => 'desc',
+        '_sort_order' => 'asc',
       ]);
     }
     $items = $this->_search_sort($request, $items);

--- a/resources/views/teachers/forms/calendar_button.blade.php
+++ b/resources/views/teachers/forms/calendar_button.blade.php
@@ -96,7 +96,7 @@
 </a>
 @endif
 
-@if(($calendar->status==="presence" || $calendar->status==="absence") && ($user->role==="manager" || ($user->role==="teacher" && $calendar->is_checked()==false)))
+@if(($calendar->status==="presence" || $calendar->status==="absence") && ($user->role==="manager" || ($user->role==="teacher" && ($calendar->trial_id>0 && $calendar->is_checked()==false))))
 {{-- 出欠変更 --}}
 <a title="{{$calendar->id}}" href="javascript:void(0);" page_title="{{__('labels.calendar_button_attendance')}}{{__('labels.edit')}}" page_form="dialog" page_url="/calendars/{{$calendar->id}}/status_update/presence?origin={{$domain}}&item_id={{$teacher->id}}&page=schedule" role="button" class="btn btn-warning btn-sm ml-1">
   <i class="fa fa-wrench" title="{{$calendar->status}}"></i>

--- a/resources/views/trials/lists.blade.php
+++ b/resources/views/trials/lists.blade.php
@@ -133,15 +133,15 @@
   </div>
   <div class="col-12 col-md-4">
     <div class="form-group">
-      <label for="is_desc_1" class="w-100">
+      <label for="is_asc_1" class="w-100">
         {{__('labels.sort_no')}}
       </label>
       <label class="mx-2">
-      <input type="checkbox" value="1" name="is_desc" id="is_desc_1" class="icheck flat-green"
-      @if(isset($filter['sort']['is_desc']) && $filter['sort']['is_desc']==true)
+      <input type="checkbox" value="1" name="is_asc" id="is_asc_1" class="icheck flat-green"
+      @if(isset($filter['sort']['is_asc']) && $filter['sort']['is_asc']==true)
         checked
       @endif
-      >{{__('labels.date')}} {{__('labels.desc')}}
+      >{{__('labels.date')}} {{__('labels.asc')}}
       </label>
     </div>
   </div>


### PR DESCRIPTION
検索フォームも降順のソートフォームから、昇順
体験授業の講師は編集できなくする