### PR TITLE
シフト一覧を削除するとエラーがでます。

### DIFF
--- a/app/Models/UserCalendarSetting.php
+++ b/app/Models/UserCalendarSetting.php
@@ -440,8 +440,10 @@ EOT;
       $calendar->dispose();
     }
     */
-    //契約処理
-    $this->agreement_update($user_id);
+    if(isset($user_id) && $this->is_teaching()==true){
+      //契約処理
+      $this->agreement_update($user_id);
+    }
     $this->delete();
 
   }


### PR DESCRIPTION
②本件は、生徒のmemberが存在しない、
③事務員のカレンダー設定は、契約が関与しない