### PR TITLE
hotfix/2021050701

### DIFF
--- a/resources/views/dashboard/widget/tasks.blade.php
+++ b/resources/views/dashboard/widget/tasks.blade.php
@@ -101,6 +101,8 @@
                         {{$curriculum->name}}
                       </small>
                     @endforeach
+                  @endif
+                  @if($item->textbooks->count() > 0)
                     @foreach($item->textbooks as $textbook)
                       <small class="badge badge-secondary">
                         <i class="fa fa-book"></i>

--- a/resources/views/dashboard/widget/tasks.blade.php
+++ b/resources/views/dashboard/widget/tasks.blade.php
@@ -89,20 +89,26 @@
                     </small>
                   </div>
                   --}}
+                  <div class="col-12">
                   @if($item->curriculums->count() > 0)
-                    <div class="col-12">
                       <small class="badge badge-primary">
+                        <i class="fa fa-tag"></i>
                         {{$item->curriculums->first()->subjects->first()->name}}
                       </small>
-                    </div>
-                    <div class="col-12">
-                      @foreach($item->curriculums as $curriculum)
-                      <small class="badge badge-primary">
+                    @foreach($item->curriculums as $curriculum)
+                      <small class="badge badge-info">
+                        <i class="fa fa-pencil-alt"></i>
                         {{$curriculum->name}}
                       </small>
-                      @endforeach
-                    </div>
+                    @endforeach
+                    @foreach($item->textbooks as $textbook)
+                      <small class="badge badge-secondary">
+                        <i class="fa fa-book"></i>
+                        {{$textbook->name}}
+                      </small>
+                    @endforeach
                   @endif
+                  </div>
                   <div class="col-12">
                     @if( $item->task_reviews->count() > 0)
                       @foreach($item->task_reviews as $review)

--- a/resources/views/tasks/simple_details.blade.php
+++ b/resources/views/tasks/simple_details.blade.php
@@ -70,6 +70,7 @@
           @foreach($item->curriculums as $curriculum)
             @foreach($curriculum->subjects as $subject)
             <small class="badge badge-primary">
+              <i class="fa fa-tag"></i>
               {{$subject->name}}
             </small>
             @endforeach
@@ -80,8 +81,20 @@
         <label>{{__('labels.curriculums')}}</label>
         <div class="form-group">
           @foreach($item->curriculums as $curriculum)
-          <small class="badge badge-primary">
+          <small class="badge badge-info">
+            <i class="fa fa-pencil-alt"></i>
             {{$curriculum->name}}
+          </small>
+          @endforeach
+        </div>
+      </div>
+      <div class="col-12">
+        <label>{{__('labels.textbooks')}}</label>
+        <div class="form-group">
+          @foreach($item->textbooks as $textbook)
+          <small class="badge badge-secondary">
+            <i class="fa fa-book"></i>
+            {{$textbook->name}}
           </small>
           @endforeach
         </div>


### PR DESCRIPTION
科目 : primary  fa-tagで表示
単元：info   fa-pencil-altで表示
テキスト:secondary fa-bookで表示

生徒の単元一覧と、単元詳細に表記追加