### PR TITLE
契約情報をすべて作り替えるためにseederの修正と削除メソッドの追加

### DIFF
--- a/app/Models/Agreement.php
+++ b/app/Models/Agreement.php
@@ -266,4 +266,11 @@ class Agreement extends Model
       }
       return $this;
     }
+
+    public function dispose(){
+      $this->agreement_statements->map(function($item){
+        return $item->dispose();
+      });
+      $this->delete();
+    }
 }

--- a/app/Models/Agreement.php
+++ b/app/Models/Agreement.php
@@ -266,7 +266,9 @@ class Agreement extends Model
       }
       return $this;
     }
-
+    
+    //メンテナンス用のため通常は使用しない
+    //契約は削除しない
     public function dispose(){
       $this->agreement_statements->map(function($item){
         return $item->dispose();

--- a/app/Models/AgreementStatement.php
+++ b/app/Models/AgreementStatement.php
@@ -104,7 +104,9 @@ class AgreementStatement extends Model
         return null;
       }
     }
-
+    
+    //メンテナンス用のため通常は使用しない
+    //契約は削除しない
     public function dispose(){
       $this->user_calendar_member_settings()->detach();
       $this->delete();

--- a/app/Models/AgreementStatement.php
+++ b/app/Models/AgreementStatement.php
@@ -104,4 +104,9 @@ class AgreementStatement extends Model
         return null;
       }
     }
+
+    public function dispose(){
+      $this->user_calendar_member_settings()->detach();
+      $this->delete();
+    }
 }

--- a/database/seeds/AgreementTableSeeder.php
+++ b/database/seeds/AgreementTableSeeder.php
@@ -23,19 +23,10 @@ class AgreementTableSeeder extends Seeder
         //すべて削除して
         $this->delete_dummy();
         //カレンダー設定から契約を作って料金を旧から入れて
-        $this->add_agreement();
-        //コミットにして開始する
-        $this->update_commit_enforced();
+        $this->_add_agreement();
       });
     }
 
-    public function update_commit_enforced(){
-      //強制登録は2020-01スタートとする
-      $target_ag = Agreement::where('status','commit')
-                            ->where('remark','enforce registered')
-                            ;
-      $target_ag->update(['start_date' => '2021-01-01']);
-    }
 
     public function delete_dummy(){
       //全部削除して入れなおす
@@ -45,18 +36,21 @@ class AgreementTableSeeder extends Seeder
       });
     }
 
-    public function add_agreement(){
+    public function _add_agreement($is_test = false){
       $target_users = User::has('enable_calendar_member_settings')->has('student')->get();
 
-      $old_tbl_fee = DB::table('hachiojisakura_management.tbl_fee')->get();
-      $old_tbl_member = DB::table('hachiojisakura_management.tbl_member')->get();
-      $old_entrance_fees = DB::table('hachiojisakura_management.tbl_entrance_fee')->get();
-      /*
-      //3月分
-      $old_tbl_fee = DB::table('hachiojisakura_management_202103.tbl_fee')->get();
-      $old_tbl_member = DB::table('hachiojisakura_management_202103.tbl_member')->get();
-      $old_entrance_fees = DB::table('hachiojisakura_management_202103.tbl_entrance_fee')->get();
-      */
+      if($is_test){
+        //メンテナンス用
+        //3月分
+        $old_tbl_fee = DB::table('hachiojisakura_management_202103.tbl_fee')->get();
+        $old_tbl_member = DB::table('hachiojisakura_management_202103.tbl_member')->get();
+        $old_entrance_fees = DB::table('hachiojisakura_management_202103.tbl_entrance_fee')->get();
+      }else{
+        $old_tbl_fee = DB::table('hachiojisakura_management.tbl_fee')->get();
+        $old_tbl_member = DB::table('hachiojisakura_management.tbl_member')->get();
+        $old_entrance_fees = DB::table('hachiojisakura_management.tbl_entrance_fee')->get();
+      }
+
       //体験生徒と職員を除く
       $target_users = $target_users->reject(function($item){
         return $item->id == 888 || $item->id == 890;
@@ -65,10 +59,6 @@ class AgreementTableSeeder extends Seeder
         $agreement = new Agreement;
         $member_setting = $user->calendar_member_settings()->first();
 
-        //承認済み契約があったら追加しない　ないと思うけど
-        if($user->student->enable_agreements_by_type('normal')->count() > 0){
-          continue;
-        }
         //既存の物を現状のロジックで契約追加
         $new_agreement = $agreement->add_from_member_setting($member_setting->id);
 
@@ -92,7 +82,7 @@ class AgreementTableSeeder extends Seeder
         }
         $new_agreement->entry_fee = $entry_fee;
         $new_agreement->status = "commit";//承認済みで登録
-        $new_agreement->start_date = "2021-03-01";
+        $new_agreement->start_date = "2000-01-01";
         $new_agreement->remark = "enforce registered";
         $new_agreement->save();
 

--- a/database/seeds/AgreementTableSeeder.php
+++ b/database/seeds/AgreementTableSeeder.php
@@ -21,14 +21,14 @@ class AgreementTableSeeder extends Seeder
 
       DB::transaction(function(){
         //すべて削除して
-        $this->delete_dummy();
+        $this->delete_all();
         //カレンダー設定から契約を作って料金を旧から入れて
         $this->_add_agreement();
       });
     }
 
 
-    public function delete_dummy(){
+    public function delete_all(){
       //全部削除して入れなおす
       $target_ag = Agreement::all();
       $target_ag->map(function($item){
@@ -94,14 +94,10 @@ class AgreementTableSeeder extends Seeder
         foreach($new_agreement->agreement_statements as $statement){
           $long_teacher_id = Teacher::find($statement->teacher_id)->user->get_tag_value('teacher_no');
           $teacher_id = preg_replace('/^10+([0-9]*)$/','$1',$long_teacher_id);
-          if($statement->course_type == "single"){
-            $course_id = 1;
-          }elseif($statement->course_type == "group"){
-            $course_id = 2;
-          }else{
-            //予想外のがきたら表示して落とす
-            dd($statement->course_type);
-            $course_id = 0;
+          $course_id = 0;
+          $_course_id = ["single" => 1, "group" => 2];
+          if(isset($_course_id[$statement->course_type])){
+            $course_id = $_course_id[$statement->course_type];
           }
           //講師と部門で料金をひっかける
           $old_fee = $old_tbl_fee->where('member_no',$student_no)

--- a/database/seeds/AgreementTableSeeder.php
+++ b/database/seeds/AgreementTableSeeder.php
@@ -30,18 +30,13 @@ class AgreementTableSeeder extends Seeder
 
 
     public function target_delete(){
-      //commitのものはすべて削除
-      $commit_ag = Agreement::where('status','commit')->get();
+      //commit,dummy,cancelのものはすべて削除
+      $commit_ag = Agreement::whereIn('status',['commit','dummy','cancel'])->get();
       $commit_ag->map(function($item){
         return $item->dispose();
       });
-      //askにnewがあるやつは削除しない
-      $ex_ag_ids =Ask::where('target_model','agreements')->where('status','new')->pluck('target_model_id');
-      $has_ask_ag = Agreement::whereNotIn('id',$ex_ag_ids)->get();
-      $has_ask_ag->map(function($item){
-        return $item->dispose();
-      });
-      $except_student_ids = Agreement::find($ex_ag_ids)->pluck('student_id');
+      //statusがnewのやつは削除しない
+      $except_student_ids = Agreement::where('status','new')->get()->pluck('student_id');
       return ['except_student_ids' => $except_student_ids ];
     }
 

--- a/database/seeds/AgreementTableSeeder.php
+++ b/database/seeds/AgreementTableSeeder.php
@@ -83,6 +83,10 @@ class AgreementTableSeeder extends Seeder
         $new_agreement->entry_fee = $entry_fee;
         $new_agreement->status = "commit";//承認済みで登録
         $new_agreement->start_date = "2000-01-01";
+        if($user->details()->status == "unsubscribe"){
+          //退会してたら終了日セット
+          $new_agreement->end_date = "2000-01-01";
+        }
         $new_agreement->remark = "enforce registered";
         $new_agreement->save();
 


### PR DESCRIPTION
契約作成のseederをすべて削除して挿入するように書き換え
実行時点の事務システムの料金とlmsのカレンダーで契約を作成する

php artian db:seed --class=AgreementTableSeeder

※　体験フロー中の未承認契約は救わないといけない
　　送信して承認待ちの契約は救わないといけない　　かも