### PR TITLE
hotfix/2021050801

### DIFF
--- a/app/Models/Student.php
+++ b/app/Models/Student.php
@@ -484,6 +484,24 @@ EOT;
     if($this->user->has_tag('student_type', 'fee_free')) return true;
     return false;
   }
+  
+  //TODO 退会・休会に関して履歴がない
+  public function is_active($date=''){
+    //指定日付の時にこのユーザーがactiveならばtrueを返す  
+    if(empty($date)) {
+      $date = date('Y-m-d');
+    }
+    else {
+      $date = date('Y-m-d', strtotime($date));
+    }
+    //退会日を以前ならactive（次の日からno active)
+    if(!empty($this->unsubscribe_date) && strtotime($this->unsubscribe_date) < strtotime($date)) return false;
+    //休会日の期間ならno active
+    if(!empty($this->recess_start_date) && !empty($this->recess_end_date) &&  
+        strtotime($this->recess_start_date) <= strtotime($date) && strtotime($this->recess_end_date) >= strtotime($date)) return false;
+
+    return true;
+  }
   public function get_brother(){
     $relations =StudentRelation::where('student_id', $this->id)->get();
     $parent_ids = [];

--- a/app/Models/Trial.php
+++ b/app/Models/Trial.php
@@ -389,10 +389,12 @@ class Trial extends Model
       if(empty($form[$tag_name])) $form[$tag_name] = '';
       TrialTag::setTag($this->id, $tag_name, $form[$tag_name], $form['create_user_id']);
     }
-    $this->write_comment('trial');
+    $remark = '';
+    if(isset($form['remark'])) $remark = $form['remark'];
+    $this->write_comment('trial', $remark);
     $this->student->profile_update($form);
   }
-  public function remark_full(){
+  public function remark_full($remark=''){
     $tagdata = $this->get_tagdata()['tagdata'];
     $ret = "";
     $is_other = false;
@@ -415,9 +417,10 @@ class Trial extends Model
         }
       }
     }
-    if(!empty($this->remark)){
+    if(empty($remark)) $remark = $this->remark;
+    if(!empty($remark)){
       $ret .= "■".__('labels.other')."\n";
-      $ret .= $this->remark;
+      $ret .= $remark;
     }
     return $ret;
   }
@@ -1396,7 +1399,9 @@ class Trial extends Model
         TrialTag::setTag($this->id, $tag_name, $form[$tag_name], $form['create_user_id']);
       }
       $this->student->profile_update($form);
-      $this->write_comment('entry');
+      $remark = '';
+      if(isset($form['remark'])) $remark = $form['remark'];
+      $this->write_comment('entry', $remark);  
     }
     Trial::where('id', $this->id)->update($update_data);
     return true;
@@ -1440,8 +1445,8 @@ class Trial extends Model
     return $daydiff;
   }
 
-  public function write_comment($type){
-    $remark = $this->remark_full();
+  public function write_comment($type, $remark=''){
+    $remark = $this->remark_full($remark);
 
     $type_title = [
       "trial" => "体験申し込み時のご要望",

--- a/app/Models/UserCalendar.php
+++ b/app/Models/UserCalendar.php
@@ -1265,7 +1265,9 @@ EOT;
       if($member->status=='cancel') continue;
       if($member->status=='fix' || $this->is_last_status($member->status)==true){
         $m = $member->user->details();
-        if($m->status!='unsubscribe' && $m->status!='recess') $active_students[] = $member;
+        if($m->is_active($this->start_time) == true) {
+          $active_students[] = $member;
+        }
       }
     }
     if(empty($end_time)) $end_time = $this->end_time;

--- a/resources/views/calendar_settings/create_form.blade.php
+++ b/resources/views/calendar_settings/create_form.blade.php
@@ -8,6 +8,9 @@
   @if($item->work!=9)
     @component('calendars.forms.select_teacher', ['_edit'=>$_edit, 'teachers'=>$teachers]); @endcomponent
     @component('calendars.forms.select_schedule_type', ['_edit'=>$_edit, 'item'=>$item, 'teachers'=>$teachers, 'is_class_schedule' => true]); @endcomponent
+    @if(isset($item->trial_id) && $item->trial_id>0)
+    <input type="hidden" name="trial_id" value="{{$item->trial_id}}" >
+    @endif
     @component('calendars.forms.select_lesson', ['_edit'=>$_edit, 'item'=>$item, 'teacher' => $teacher,'attributes' => $attributes]); @endcomponent
     @component('calendar_settings.forms.schedule_method', ['_edit'=>$_edit, 'item'=>$item, 'attributes' => $attributes, 'teacher' => $teacher]) @endcomponent
     @component('calendar_settings.forms.lesson_week', ['_edit'=>$_edit, 'item'=>$item, 'attributes' => $attributes, 'teacher' => $teacher]) @endcomponent


### PR DESCRIPTION
①英会話一人グループにする処理に対し、
退会日考慮漏れ
退会日前の予定に対しても、ステータスが退会の場合、activeなユーザーにカウントされず、一人グループにされてしまう。

②calendar_settings/createに対し、trial_idが、取得できない（hiddenフォームがない）
　→　体験申し込み＞calendar_settings/create経由で、入会のための通常授業設定すると、体験経由かどうかが分からなくなるので、生徒確認済みでカレンダー設定の登録が可能になってしまう

③入会時コメントが反映されない

