### PR TITLE
契約関係の修正

### DIFF
--- a/app/Console/Commands/MonthlyAgreementCreateCommand.php
+++ b/app/Console/Commands/MonthlyAgreementCreateCommand.php
@@ -46,7 +46,11 @@ class MonthlyAgreementCreateCommand extends Command
         }else{
           $date = date('Y-m-d',strtotime($this->argument('year')."-".$this->argument('month')));
         }
-        $student_users = User::has('student')->get();
+        //生徒を持っているユーザーの中で、体験でないもの
+        //体験の人は二か月先まで契約ができているので、作らなくてよい
+        $student_users = User::whereHas('student',function($query){
+          return $query->whereNotIn('status',["trial"]);
+        })->get();
         $target_users = $student_users->filter(function($item) use($date){
           //契約の対象になるカレンダー設定があるユーザ
           return $item->monthly_enable_calendar_settings($date)->count() > 0;

--- a/app/Models/UserCalendarMemberSetting.php
+++ b/app/Models/UserCalendarMemberSetting.php
@@ -493,12 +493,12 @@ class UserCalendarMemberSetting extends UserCalendarMember
                               ->where('lesson_week_count',$this->user->get_enable_calendar_setting_count($setting->lesson(true)))
                               ->where('is_exam',$this->user->details()->is_juken())
                               ->get();
+      //契約がある場合はその料金を返す
+      //契約がない場合は受講料マスタから取りに行く
       if($statement->count() > 0 ){
         $tuition = $statement->first()->tuition; 
-      }else{
-        $tuition = 0;
+        return $tuition;
       }
-      return $tuition;
     }
     //2020年4月1日以前のユーザーは0円で返す
     if( strtotime($this->user->created_at) > strtotime("2020/04/01") ){


### PR DESCRIPTION
・契約条件が変わったときに受講料マスタを参照せずに０円を返す不具合を修正

・体験状態の生徒は月次バッチの対象から外すように修正