### PR TITLE
体験面談で事務員の名前を表示する＋EventUserでuser_role_tagが複数の場合に送信対象が追加されない不具合解消

### DIFF
--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -202,7 +202,9 @@ class Event extends Milestone
     public function event_user_add(){
       $targets = $this->get_event_user();
       foreach($targets as $target){
-        $eu = EventUser::where('event_id', $this->id)->where('user_id' , $target->id)->first();
+        $eu = $this->event_users->where('user_id',$target->id)->first();
+
+
         if(isset($eu)) continue;
         EventUser::create([
           'event_id' => $this->id,

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -184,7 +184,7 @@ class Event extends Milestone
               $query->searchTags([['tag_key' => 'manager_type', 'tag_value'=>'admin']]);
             });
             break;
-          case "stuff":
+          case "staff":
             $target->orWhereHas('manager', function($query) use ($lesson_tag, $grade_tags) {
               $query->findStatuses(['regular'])->where('user_id', '!=', 1);
             });

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -4,10 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use App\Models\EventUser;
-use App\Models\Student;
-use App\Models\Teacher;
-use App\Models\Manager;
-use App\Models\StudentParent;
+use App\User;
 /**
  * App\Models\Event
  *
@@ -155,47 +152,61 @@ class Event extends Milestone
       }
     }
     public function get_event_user(){
-      $user_role_tag = $this->template->get_tag('user_role');
-      if(!isset($user_role_tag)) return null;
-      $target = null;
-      switch($user_role_tag->tag_value){
-        case "student":
-          $target = Student::query();
-          break;
-        case "teacher":
-          $target = Teacher::query();
-          break;
-        case "manager":
-          $target = Manager::searchTags([['tag_key' => 'manager_type', 'tag_value'=>'admin']]);
-          break;
-        case "stuff":
-          $target = Manager::query();
-          break;
-        case "parent":
-          $target = StudentParent::query();
-          break;
+      $user_role_tags = $this->template->get_tags('user_role');
+      if(!isset($user_role_tags)) return null;
+      $lesson_tag = $this->template->get_tags('lesson');
+      $grade_tags = $this->template->get_tags('grade');
+      $target = User::query();
+      foreach($user_role_tags as $user_role_tag){
+        switch($user_role_tag->tag_value){
+          case "student":
+            $target->orWhereHas('student', function($query) use ($lesson_tag, $grade_tags) {
+              $query->findStatuses(['regular'])->where('user_id', '!=', 1);
+              if(isset($lesson_tag) && count($lesson_tag)>0){
+                $query = $query->searchTags($lesson_tag);
+              }
+              if(isset($grade_tags) && count($grade_tags)>0){
+                $query = $query->searchTags($grade_tags);
+              }
+            });
+            break;
+          case "teacher":
+            $target->orWhereHas('teacher', function($query) use ($lesson_tag, $grade_tags) {
+              $query->findStatuses(['regular'])->where('user_id', '!=', 1);
+              if(isset($lesson_tag) && count($lesson_tag)>0){
+                $query = $query->searchTags($lesson_tag);
+              }
+            });
+            break;
+          case "manager":
+            $target->orWhereHas('manager', function($query) use ($lesson_tag, $grade_tags) {
+              $query->findStatuses(['regular'])->where('user_id', '!=', 1);
+              $query->searchTags([['tag_key' => 'manager_type', 'tag_value'=>'admin']]);
+            });
+            break;
+          case "stuff":
+            $target->orWhereHas('manager', function($query) use ($lesson_tag, $grade_tags) {
+              $query->findStatuses(['regular'])->where('user_id', '!=', 1);
+            });
+            break;
+          case "parent":
+            $target->orWhereHas('student_parent', function($query) use ($lesson_tag, $grade_tags) {
+              $query->findStatuses(['regular'])->where('user_id', '!=', 1);
+            });
+            break;
+        }
       }
       if($target==null) return null;
-      $targets = $target->findStatuses(['regular'])->where('user_id', '!=', 1);
-      $lesson_tag = $this->template->get_tags('lesson');
-      if(isset($lesson_tag) && count($lesson_tag)>0){
-        $targets = $targets->searchTags($lesson_tag);
-      }
-      $grade_tags = $this->template->get_tags('grade');
-      if(isset($grade_tags) && count($grade_tags)>0){
-        $targets = $targets->searchTags($grade_tags);
-      }
-      $targets = $targets->get();
-      return $targets;
+      return $target->get();
     }
     public function event_user_add(){
       $targets = $this->get_event_user();
       foreach($targets as $target){
-        $eu = EventUser::where('event_id', $this->id)->where('user_id' , $target->user_id)->first();
+        $eu = EventUser::where('event_id', $this->id)->where('user_id' , $target->id)->first();
         if(isset($eu)) continue;
         EventUser::create([
           'event_id' => $this->id,
-          'user_id' => $target->user_id,
+          'user_id' => $target->id,
           'status' => 'new',
         ]);
       }

--- a/config/attribute/user_role.php
+++ b/config/attribute/user_role.php
@@ -3,7 +3,7 @@ return array(
   'student' => '生徒',
   'teacher' => '講師',
   'parent' => '契約者',
-  'stuff' => '事務員',
+  'staff' => '事務員',
   'manager' => '事務員(管理者)',
 );
 ?>

--- a/config/attributes.php
+++ b/config/attributes.php
@@ -3297,8 +3297,8 @@
 			"parent_attribute_value" => "",
 			"sort_no" => "3",
 		],
-		"stuff" => [
-			"attribute_value" => "stuff",
+		"staff" => [
+			"attribute_value" => "staff",
 			"attribute_name" => "事務員",
 			"parent_attribute_key" => "",
 			"parent_attribute_value" => "",

--- a/resources/views/event_users/create.blade.php
+++ b/resources/views/event_users/create.blade.php
@@ -20,7 +20,7 @@
             @foreach($event->get_event_user() as $target)
               @if(!$event->has_user($target->user_id))
                 <option value="{{$target->user_id}}"
-                >{{$target->name()}}</option>
+                >{{$target->details()->name()}}</option>
               @endif
             @endforeach
           </select>


### PR DESCRIPTION
体験面談で事務員の名前を表示する
EventUserでuser_role_tagが複数の場合に送信対象が追加されない不具合解消

リリース時にデータのリカバリが必要
```
select * from event_template_tags where tag_key='user_role' and tag_value='stuff';
update event_template_tags set tag_value='staff' where tag_key='user_role' and tag_value='stuff';

```